### PR TITLE
Less buggy solution to solving the floating footer problem

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -114,16 +114,17 @@ pre, form, fieldset, table, th, td, select, input {
 
 body {
 	background: var(--background);
-	font-size: 15px;
-}
-
-body.card, body.fixed_navbar {
 	padding-bottom: var(--footer-height);
-	min-height: calc(100vh - 60px);
+	font-size: 15px;
 	position: relative;
 }
 
+body.card {
+	min-height: calc(100vh - 30px);
+}
+
 body.fixed_navbar {
+	min-height: calc(100vh - 90px);
 	padding-top: 60px;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -26,6 +26,8 @@
 	--popup-goback-background: var(--popup-red);
 	--popup-goback-text: #222;
 	--popup-border: 1px solid var(--popup-red);
+
+	--footer-height: 30px;
 }
 
 @font-face {
@@ -115,10 +117,14 @@ body {
 	font-size: 15px;
 }
 
-body.fixed_navbar {
-	padding-top: 60px;
+body.card, body.fixed_navbar {
+	padding-bottom: var(--footer-height);
 	min-height: calc(100vh - 60px);
 	position: relative;
+}
+
+body.fixed_navbar {
+	padding-top: 60px;
 }
 
 nav {
@@ -314,6 +320,7 @@ body > footer {
 	align-items: center;
 	width: 100%;
 	background: var(--post);
+	position: absolute;
 	bottom: 0;
 }
 


### PR DESCRIPTION
I found that my previous fix for this had a problem where the footer would end up on the wrong spot in very short posts that had no comments, sorry about that!

This is a much simpler fix to the problem that also avoids running into that issue.

After another look I realized that the problem revolves around what classes the body has. Only the fixed_navbar class had `position: relative;` and therefore when the body lost that from turning "Keep navbar fixed" off, the footer was no longer relative to the body. Hence why it would show up at the bottom of the initial viewport and be fixed there.

This fix just restores the old CSS file and gives the card class the same properties as the fixed_navbar class besides it's top padding in order to make sure both are in line with each other and combat that problem.