### PR TITLE
Use boot-time for sleep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "boot-time"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b094c3b8fd302af9393806bb8af1b83a5a948ca7a91e87a92ea32167157f6"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "brotli"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,6 +1072,7 @@ version = "0.31.0"
 dependencies = [
  "askama",
  "base64",
+ "boot-time",
  "brotli",
  "build_html",
  "cached",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ fastrand = "2.0.1"
 log = "0.4.20"
 pretty_env_logger = "0.5.0"
 dotenvy = "0.15.7"
+boot-time = "0.1.2"
 
 [dev-dependencies]
 lipsum = "0.9.0"

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -10,6 +10,10 @@ use log::info;
 
 use serde_json::json;
 
+use boot_time; /*"This library reimplements std::time::Instant to use suspend-aware monotonic time if target system supports it.
+Otherwise it uses monotonic time or reexports std::time::Instant."
+See #22. Will be obsoleted when https://github.com/tokio-rs/tokio/issues/3185 is resolved. */
+
 static REDDIT_ANDROID_OAUTH_CLIENT_ID: &str = "ohXpoqrZYub1kg";
 
 static AUTH_ENDPOINT: &str = "https://accounts.reddit.com";

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::collections::HashMap;
 
 use crate::{
 	client::{CLIENT, OAUTH_CLIENT},
@@ -10,9 +10,10 @@ use log::info;
 
 use serde_json::json;
 
-use boot_time; /*"This library reimplements std::time::Instant to use suspend-aware monotonic time if target system supports it.
+/*"This library reimplements std::time::Instant to use suspend-aware monotonic time if target system supports it.
 Otherwise it uses monotonic time or reexports std::time::Instant."
 See #22. Will be obsoleted when https://github.com/tokio-rs/tokio/issues/3185 is resolved. */
+use boot_time::Duration;
 
 static REDDIT_ANDROID_OAUTH_CLIENT_ID: &str = "ohXpoqrZYub1kg";
 


### PR DESCRIPTION
Boot-time: "This library reimplements std::time::Instant to use suspend-aware monotonic time if target system supports it.
Otherwise it uses monotonic time or reexports std::time::Instant."

Will be obsoleted when https://github.com/tokio-rs/tokio/issues/3185 is resolved.

Fixes #22
