### PR TITLE
Handle errors from reddit

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -320,7 +320,7 @@ pub async fn json(path: String, quarantine: bool) -> Result<Value, String> {
 							let json: Value = value;
 							// If Reddit returned an error
 							if json["error"].is_i64() {
-								if json["reason"] == "Unauthorized" { // OAuth token has expired
+								if json["message"] == "Unauthorized" { // OAuth token has expired
 									error!("Forcing a token refresh");
 									let () = force_refresh_token().await;
 									return Err("OAuth token has expired. Please refresh the page!".to_string())

--- a/src/client.rs
+++ b/src/client.rs
@@ -320,28 +320,19 @@ pub async fn json(path: String, quarantine: bool) -> Result<Value, String> {
 							let json: Value = value;
 							// If Reddit returned an error
 							if json["error"].is_i64() {
-								Err(
-									json["reason"]
-										.as_str()
-										.unwrap_or_else(|| {
-											json["message"].as_str().unwrap_or_else(|| {
-												eprintln!("{REDDIT_URL_BASE}{path} - Error parsing reddit error");
-												"Error parsing reddit error"
-											})
-										})
-										.to_string(),
-								)
+								if json["reason"] == "Unauthorized" { // OAuth token has expired
+									error!("Forcing a token refresh");
+									let () = force_refresh_token().await;
+									return Err("OAuth token has expired. Please refresh the page!".to_string())
+								}
+								Err(format!("Reddit error {} \"{}\": {}", json["error"], json["reason"], json["message"]))
+
 							} else {
 								Ok(json)
 							}
 						}
 						Err(e) => {
-							error!("Got a bad response from reddit {e}. Status code: {status}");
-							// Unauthorized; token expired
-							if status == 401 {
-								error!("Forcing a token refresh");
-								let () = force_refresh_token().await;
-							}
+							error!("Got an invalid response from reddit {e}. Status code: {status}");
 							if status.is_server_error() {
 								Err("Reddit is having issues, check if there's an outage".to_string())
 							} else {

--- a/src/client.rs
+++ b/src/client.rs
@@ -320,13 +320,13 @@ pub async fn json(path: String, quarantine: bool) -> Result<Value, String> {
 							let json: Value = value;
 							// If Reddit returned an error
 							if json["error"].is_i64() {
-								if json["message"] == "Unauthorized" { // OAuth token has expired
+								// OAuth token has expired; http status 401
+								if json["message"] == "Unauthorized" {
 									error!("Forcing a token refresh");
 									let () = force_refresh_token().await;
-									return Err("OAuth token has expired. Please refresh the page!".to_string())
+									return Err("OAuth token has expired. Please refresh the page!".to_string());
 								}
 								Err(format!("Reddit error {} \"{}\": {}", json["error"], json["reason"], json["message"]))
-
 							} else {
 								Ok(json)
 							}


### PR DESCRIPTION
A 401 code is still an `Ok(<...>)` response, so the error handling was in the wrong place.

Hopefully the conditional logic (`json["reason"] == "Unauthorized"`) is correct;

The information reported to the browser _should_ be improved.

It's obvious that Libreddit wasn't designed with error-handling in mind.

Linked issue: #22
