### PR TITLE
Replace www.unddit.com with undelete.pullpush.io

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ pub static CONFIG: Lazy<Config> = Lazy::new(Config::load);
 
 // This serves as the frontend for the Pushshift API - on removed comments, this URL will
 // be the base of a link, to display removed content (on another site).
-pub const DEFAULT_PUSHSHIFT_FRONTEND: &str = "www.unddit.com";
+pub const DEFAULT_PUSHSHIFT_FRONTEND: &str = "undelete.pullpush.io";
 
 /// Stores the configuration parsed from the environment variables and the
 /// config file. `Config::Default()` contains None for each setting.

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,8 +9,8 @@ use std::{env::var, fs::read_to_string};
 // first request) and contains the instance settings.
 pub static CONFIG: Lazy<Config> = Lazy::new(Config::load);
 
-// This serves as the frontend for the Pushshift API - on removed comments, this URL will
-// be the base of a link, to display removed content (on another site).
+// This serves as the frontend for an archival API - on removed comments, this URL
+// will be the base of a link, to display removed content (on another site).
 pub const DEFAULT_PUSHSHIFT_FRONTEND: &str = "undelete.pullpush.io";
 
 /// Stores the configuration parsed from the environment variables and the


### PR DESCRIPTION
[Unddit](https://www.unddit.com) shut down for a while, and have been ineffective after [PushShift](https://pushshift.io/) drastically changed. [PullPush](https://pullpush.io/) is a spiritual successor to PushShift and [also provide a service similar to Unddit](https://undelete.pullpush.io/). I went ahead and replaced the string to a working link so that removed post links aren't broken by default.