### PR TITLE
Update docker-compose.yml to remove duplicate 'security_opt'

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   web:
     image: quay.io/redlib/redlib

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,11 @@ services:
     read_only: true
     security_opt:
       - no-new-privileges:true
+      - seccomp="seccomp-redlib.json"
     cap_drop:
       - ALL
     networks:
       - redlib
-    security_opt:
-      - seccomp="seccomp-redlib.json"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "--tries=1", "http://localhost:8080/settings"]
       interval: 5m


### PR DESCRIPTION
Docker compose complains with "mapping key "security_opt" already defined"