### PR TITLE
Make HLS support checking more robust

### DIFF
--- a/static/playHLSVideo.js
+++ b/static/playHLSVideo.js
@@ -9,7 +9,7 @@
             var autoplay = oldVideo.classList.contains("hls_autoplay");
 
             // If HLS is supported natively then don't use hls.js
-            if (oldVideo.canPlayType(source.type)) {
+            if (oldVideo.canPlayType(source.type) === "probably") {
                 if (autoplay) {
                     oldVideo.play();
                 }


### PR DESCRIPTION
Video playback is broken for me on Android Firefox/123.0.

Based on the documentation here: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/canPlayType

According to the page above, the canPlayType call has 3 possible return values: "", maybe, probably. Maybe means "There is not enough information to determine whether the media can play" so simply checking if the string has a value seems to be incorrect in this case. This change updates the check to test if the browser returns at least "probably".