### PR TITLE
Fix anchor tags scrolling to the wrong place when fixed navbar is enabled

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -112,6 +112,16 @@ pre, form, fieldset, table, th, td, select, input {
 	font-family: "Inter", sans-serif;
 }
 
+html.fixed_navbar {
+	scroll-padding-top: 50px;
+}
+
+@media screen and (max-width: 800px) {
+	html.fixed_navbar {
+		scroll-padding-top: 100px;
+	}
+}
+
 body {
 	background: var(--background);
 	padding-bottom: var(--footer-height);

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,7 @@
 {% import "utils.html" as utils %}
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="{% if prefs.fixed_navbar == "on" %}fixed_navbar{% endif %}">
 	<head>
 		{% block head %}
 		<title>{% block title %}Redlib{% endblock %}</title>


### PR DESCRIPTION
Fixes https://github.com/redlib-org/redlib/issues/79

The site didn't account for the navbar being there when it jumps somewhere. Adding the `scroll-padding-top` attribute fixes this by telling the browser to scroll further.

I had to add the `fixed_navbar` class to `html` as otherwise you'd have to add it to each element you're jumping too, which would be far more complicated and would require actual code.
Every other reference to the `fixed_navbar` class in `style.css` is targeting the class for a specific type of element, so it doesn't have any extra effects but might be something to keep in mind if any more work is done with the class.