### PR TITLE
Update hide HLS env var to match documentation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -125,7 +125,7 @@ impl Config {
 			default_show_nsfw: parse("REDLIB_DEFAULT_SHOW_NSFW"),
 			default_blur_nsfw: parse("REDLIB_DEFAULT_BLUR_NSFW"),
 			default_use_hls: parse("REDLIB_DEFAULT_USE_HLS"),
-			default_hide_hls_notification: parse("REDLIB_DEFAULT_HIDE_HLS"),
+			default_hide_hls_notification: parse("REDLIB_DEFAULT_HIDE_HLS_NOTIFICATION"),
 			default_hide_awards: parse("REDLIB_DEFAULT_HIDE_AWARDS"),
 			default_hide_score: parse("REDLIB_DEFAULT_HIDE_SCORE"),
 			default_subscriptions: parse("REDLIB_DEFAULT_SUBSCRIPTIONS"),


### PR DESCRIPTION
The documentation/examples here don't match the variable that gets parsed, leading to the variable not taking effect if the documentation/examples are followed.

I've updated the expected variable name in code, as "HIDE_HLS" is only referenced a single time, while every other reference is to "HIDE_HLS_NOTIFICATION", but this *is* a breaking change; anyone who had `REDLIB_DEFAULT_HIDE_HLS=on` will see their setting stop working.

If you'd prefer, I can amend the PR/fix to instead update the documentation to match the code, which would make the fix non-breaking, at the expense of consistency of variable names.