### PR TITLE
Stop post footer text from disappearing when screen is exactly 480px wide

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1098,7 +1098,7 @@ a.search_subreddit:hover {
 	display: auto;
 }
 
-@media screen and (min-width: 480px) {
+@media screen and (min-width: 481px) {
 	#post_links > li.mobile_item {
 			display: none;
 	}


### PR DESCRIPTION
Just happened to notice this funny little bug.

The media attributes for controlling which text would appear in the footer both did nothing at 480px so I just made it so the one for the mobile links would display at 480px and left the desktop links as is.