### PR TITLE
Handle preview embedding better

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -895,7 +895,7 @@ pub fn rewrite_urls(input_text: &str) -> String {
 
 	// Rewrite external media previews to Redlib
 	loop {
-    	if REDDIT_PREVIEW_REGEX.find(&text1).is_none() {
+    		if REDDIT_PREVIEW_REGEX.find(&text1).is_none() {
 			return text1;
 		} else {
 			let formatted_url = format_url(REDDIT_PREVIEW_REGEX.find(&text1).map(|x| x.as_str()).unwrap_or_default());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -895,14 +895,14 @@ pub fn rewrite_urls(input_text: &str) -> String {
 
 	// Rewrite external media previews to Redlib
 	loop {
-    		if REDDIT_PREVIEW_REGEX.find(&text1).is_none() {
+		if REDDIT_PREVIEW_REGEX.find(&text1).is_none() {
 			return text1;
 		} else {
 			let formatted_url = format_url(REDDIT_PREVIEW_REGEX.find(&text1).map(|x| x.as_str()).unwrap_or_default());
 
 			let image_url = REDLIB_PREVIEW_LINK_REGEX.find(&formatted_url).map_or("", |m| m.as_str()).to_string();
 			let image_text = REDLIB_PREVIEW_TEXT_REGEX.find(&formatted_url).map_or("", |m| m.as_str()).to_string();
-			
+
 			let image_to_replace = format!("<a href=\"{image_url}{image_text}").replace(">>", ">");
 			let image_replacement = format!("<a href=\"{image_url}<img src=\"{image_url}</a>");
 

--- a/static/style.css
+++ b/static/style.css
@@ -1177,11 +1177,13 @@ a.search_subreddit:hover {
 
 .comment img {
 	max-width: 50%;
+	height: auto;
 }
 
 @media screen and (max-width: 500px) {
 	.comment img {
 		max-width: 80%;
+		height: auto;
 	}
 }
 


### PR DESCRIPTION
Of course I happened to discover some bugs _after_ https://github.com/redlib-org/redlib/pull/85 was merged.

1. The regex matches would sometimes match more than expected depending on how the post was typed out. This would cause parts of the post to get overwritten or merged with the embed. I made the wildcard matches lazy to prevent this.
2. Gifs would duplicate because the replace parameter wasn't specific enough and would match already existing img blocks. Now it has to match the entirety of `<a href="PREVIEW_LINK">TEXT</a>` which is then replaced by `<a href ="PREVIEW_LINK"><img src="PREVIEW_LINK"></a>`
3. Embedded images in comments wouldn't keep their aspect ratio when the screen got small because I forgot to specify the height attribute as auto. All I did was add that in the CSS.

On top of that I also trashed the if else around the loop as in cases where it's true we end up doing the comparison twice for no reason.