### PR TITLE
Simplify the Docker image build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.devcontainer

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-.devcontainer

--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   REGISTRY_IMAGE: quay.io/redlib/redlib
-  PLATFORMS: "linux/amd64,linux/arm64,linux/arm/v7"
+  PLATFORMS: "linux/amd64,linux/arm64"
 
 jobs:
   build:

--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -55,7 +55,7 @@ jobs:
           file: Dockerfile
           push: true
       -
-        name: Build and push
+        name: Build and push (Pull Request)
         if: github.event_name == 'pull_request'
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -7,17 +7,13 @@ on:
       - completed
 env:
   REGISTRY_IMAGE: quay.io/redlib/redlib
+  PLATFORMS: "linux/amd64,linux/arm64,linux/arm/v7"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - { platform: linux/amd64, target: x86_64-unknown-linux-musl}
-          - { platform: linux/arm64, target: aarch64-unknown-linux-musl}
-          - { platform: linux/arm/v7, target: armv7-unknown-linux-musleabihf}
     steps:
       -
         name: Checkout
@@ -39,6 +35,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Login to Quay.io Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -46,77 +43,23 @@ jobs:
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
       -
         name: Build and push
-        id: build
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ env.PLATFORMS }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }}
           file: Dockerfile
-          build-args: TARGET=${{ matrix.target }}
+          push: true
       -
-        name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-      -
-        name: Upload digest
-        uses: actions/upload-artifact@v3
+        name: Build and push
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v5
         with:
-          name: digests
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-  merge:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      -
-        name: Download digests
-        uses: actions/download-artifact@v3
-        with:
-          name: digests
-          path: /tmp/digests
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-            type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
-      -
-        name: Login to Quay.io Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
-      -
-        name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-
-      - name: Push README to Quay.io
-        uses: christian-korneck/update-container-description-action@v1
-        env:
-          DOCKER_APIKEY: ${{ secrets.APIKEY__QUAY_IO }}
-        with:
-          destination_container_repo: quay.io/redlib/redlib
-          provider: quay
-          readme_file: 'README.md'
-
-      -
-        name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
-          
+          context: .
+          platforms: ${{ env.PLATFORMS }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }}
+          file: Dockerfile
+          push: false

--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -1,10 +1,12 @@
 name: Container build
 
 on:
-  workflow_run:
-    workflows: ["Release Build"]
-    types:
-      - completed
+  pull_request:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
+
 env:
   REGISTRY_IMAGE: quay.io/redlib/redlib
   PLATFORMS: "linux/amd64,linux/arm64,linux/arm/v7"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/rust:1.78-slim-bookworm AS builder
 WORKDIR /app
 COPY ./ ./
 
-RUN cargo test --release
+# RUN cargo test --release
 RUN cargo build --release
 
 FROM docker.io/library/debian:bookworm-slim AS release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 FROM docker.io/library/rust:1.78-slim-bookworm AS builder
 
+WORKDIR /app
 COPY ./ ./
-
-# Base image appears to pre-install these
-# RUN apt-get update
-# RUN apt-get install -y ca-certificates
 
 RUN cargo test --release
 RUN cargo build --release
@@ -14,7 +11,7 @@ FROM docker.io/library/debian:bookworm-slim AS release
 WORKDIR /app
 # ca-certificates are not preinstalled in the base image
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
-COPY --from=builder --chown=600 target/release/redlib /app/
+COPY --from=builder --chown=600 /app/target/release/redlib /app/
 
 RUN useradd -M redlib
 USER redlib


### PR DESCRIPTION
The original PR by @nohoster, #59, aimed to completely overhaul the container build pipeline to greatly speed up builds by de-deduplicating work by downloading redlib binaries built in CI. However, `build-artifacts` for whatever reason, does not trigger the upload artifacts step. This means issues such as #104, #122, and apparently, #118 (based on the comment about updating) appear. This has not been fixed in awhile (5 releases!).

As a result, I propose moving back towards a more traditional Dockerfile. Instead of downloading a pre-completed build, the contents of the git tree are built as usual.

This PR also re-introduces testing in the Dockerfile, and both the builder and release images are on the same distro, as opposed to the ubuntu -> alpine pattern as before. Doing it this way also ensures users can build for more platforms than 64-bit x86 and ARM, as well as 32-bit ARM.