### PR TITLE
Create build-artifacts on release

### DIFF
--- a/.github/workflows/build-artifacts.yaml
+++ b/.github/workflows/build-artifacts.yaml
@@ -7,6 +7,8 @@ on:
       - "compose.*"
     branches:
       - "main"
+  release:
+    types: [published]
 
 env: 
   CARGO_TERM_COLOR: always
@@ -60,7 +62,6 @@ jobs:
 
       - name: Upload release
         uses: softprops/action-gh-release@v1
-        if: github.base_ref != 'main' && github.event_name == 'release'
         with:
           tag_name: ${{ steps.version.outputs.VERSION }}
           name: ${{ steps.version.outputs.VERSION }} - ${{ github.event.head_commit.message }}


### PR DESCRIPTION
Only build artifacts on published release.

As of now the artifacts are never created as the branch must be "main" on line 9 but must not be "main" on line 63.

fixes #71
fixes #74
fixes #122  
fixes #132 