### PR TITLE
fix: healthcheck in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ USER redlib
 EXPOSE 8080
 
 # Run a healthcheck every minute to make sure redlib is functional
-HEALTHCHECK --interval=1m --timeout=3s CMD wget --spider --q http://localhost:8080/settings || exit 1
+HEALTHCHECK --interval=1m --timeout=3s CMD wget --spider -q http://localhost:8080/settings || exit 1
 
 CMD ["redlib"]
 


### PR DESCRIPTION
Fix typo causing wget to return a warning:

```
# wget --q
wget: option '--q' is ambiguous; possibilities: '--quiet' '--quota'
```