### PR TITLE
hotfix: Dockerfile redlib installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,9 @@ FROM alpine:3.19
 
 ARG TARGET
 
-RUN apk add --no-cache curl
+RUN apk add --no-cache wget
 
-RUN curl -L https://github.com/redlib-org/redlib/releases/latest/download/redlib-${TARGET}.tar.gz | \
-    tar xz -C /usr/local/bin/
+RUN wget -q -O /usr/local/bin/redlib https://github.com/redlib-org/redlib/releases/latest/download/redlib && chmod +x /usr/local/bin/redlib
 
 RUN adduser --home /nonexistent --no-create-home --disabled-password redlib
 USER redlib


### PR DESCRIPTION
This PR adds hotfix, specifically the section where the binary is downloaded and installed from GitHub refactors the line for the redlib binarry installation.

If you, as the maintainer, are planning a different approach, please feel free to close this PR.

EDIT: 
The active PR at https://github.com/redlib-org/redlib/pull/123 seems like better approach