### PR TITLE
Remove obsolete references to latest-arm and latest-armv7 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,12 +203,6 @@ docker logs -f redlib
 
 ### Docker CLI
 
-> [!IMPORTANT]
-> If deploying on:
->
-> - an `arm64` platform, use the `quay.io/redlib/redlib:latest-arm` image instead.
-> - an `armv7` platform, use the `quay.io/redlib/redlib:latest-armv7` image instead.
-
 Deploy Redlib:
 
 ```bash

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,8 +1,6 @@
 services:
   redlib:
     image: quay.io/redlib/redlib:latest
-    # image: quay.io/redlib/redlib:latest-arm # uncomment if you use arm64
-    # image: quay.io/redlib/redlib:latest-armv7 # uncomment if you use armv7
     restart: always
     container_name: "redlib"
     ports:


### PR DESCRIPTION
Just a couple more documentation fixes; since the recent fixes to the build, the `latest` tag now includes both ARM and ARM64 images. (And the `latest-arm` and `latest-armv7` tags point to some images from 3 months ago.)