### PR TITLE
Add font-weight range in @font-face rule

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -34,6 +34,7 @@
 	font-family: 'Inter';
 	src: url('/Inter.var.woff2') format('woff2-variations');
 	font-style: normal;
+	font-weight: 100 900;
 }
 
 /* Automatic theme selection */


### PR DESCRIPTION
This makes Safari render the bold weights correctly which otherwise looks wrong.

See how the subreddit name (i.e _r/AskReddit_) is rendered between the images below.

| Before | After |
| -------|------|
| ![libreddit_cssfw_before](https://github.com/redlib-org/redlib/assets/2759499/d1ee9b30-971c-44b4-a5e2-17196bc5ec5b) | ![libreddit_cssfw_after](https://github.com/redlib-org/redlib/assets/2759499/0e287603-53f6-4efb-812a-968ea99f6f44) |
