### PR TITLE
Make server listen on both IPv6 and IPv4 by default to fix docker healthcheck

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -135,7 +135,7 @@ async fn main() {
 				.long("address")
 				.value_name("ADDRESS")
 				.help("Sets address to listen on")
-				.default_value("0.0.0.0")
+				.default_value("[::]")
 				.num_args(1),
 		)
 		.arg(


### PR DESCRIPTION
As I stated in #108, with docker added support to IPv6, the healthcheck fails since the server only listens on IPv4 by default. The best fix is to make the server listen on both IPv6 and IPv4 by default.

Otherwise, this can be fixed by replacing `localhost` with `127.0.0.1` in the healthchecks