### PR TITLE
fix(oauth): reset rate limit earlier in refresh cycle

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -320,6 +320,7 @@ pub async fn json(path: String, quarantine: bool) -> Result<Value, String> {
 	let current_rate_limit = OAUTH_RATELIMIT_REMAINING.load(Ordering::Relaxed);
 	if current_rate_limit < 10 {
 		warn!("Rate limit {current_rate_limit} is low. Spawning force_refresh_token()");
+		OAUTH_RATELIMIT_REMAINING.store(99, Ordering::Relaxed);
 		tokio::spawn(force_refresh_token());
 	}
 

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -133,7 +133,6 @@ pub async fn token_daemon() {
 pub async fn force_refresh_token() {
 	trace!("Rolling over refresh token. Current rate limit: {}", OAUTH_RATELIMIT_REMAINING.load(Ordering::Relaxed));
 	OAUTH_CLIENT.write().await.refresh().await;
-	OAUTH_RATELIMIT_REMAINING.store(99, Ordering::Relaxed);
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
reset rate limit as soon as we encounter a low rate limit, rather than once we finish retrieving a new token

if this doesn't work, my next choice is a single thread owning write access to `OAUTH_CLIENT` that can receive a reset signal from anywhere, and keeps track of the rate limits to allow both the expiry event and the rate limit event to reset it, without causing concurrent token retrievals