### PR TITLE
feat: add download button on image/gif/video posts

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1131,17 +1131,9 @@ pub fn url_path_basename(path: &str) -> String {
 		path.to_string()
 	} else {
 		let mut url = url_result.unwrap();
-		url
-			.path_segments_mut()
-			.unwrap()
-			.pop_if_empty();
+		url.path_segments_mut().unwrap().pop_if_empty();
 
-		url
-			.path_segments()
-			.unwrap()
-			.last()
-			.unwrap()
-			.to_string()
+		url.path_segments().unwrap().last().unwrap().to_string()
 	}
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -237,7 +237,7 @@ impl Media {
 		let alt_url = alt_url_val.map_or(String::new(), |val| format_url(val.as_str().unwrap_or_default()));
 
 		let download_name = if post_type == "image" || post_type == "gif" || post_type == "video" {
-			let permalink_base = url_path_basename(&data["permalink"].as_str().unwrap_or_default());
+			let permalink_base = url_path_basename(data["permalink"].as_str().unwrap_or_default());
 			let media_url_base = url_path_basename(url_val.as_str().unwrap_or_default());
 
 			format!("redlib_{permalink_base}_{media_url_base}")

--- a/static/style.css
+++ b/static/style.css
@@ -1110,12 +1110,12 @@ a.search_subreddit:hover {
 	margin-right: 15px;
 }
 
-#post_links > li.desktop_item {
+.desktop_item {
 	display: auto;
 }
 
 @media screen and (min-width: 481px) {
-	#post_links > li.mobile_item {
+	.mobile_item {
 			display: none;
 	}
 }
@@ -1770,9 +1770,10 @@ td, th {
 	}
 
 	#post_links > li { margin-right: 10px }
-	#post_links > li.desktop_item { display: none }
-	#post_links > li.mobile_item { display: auto }
 	.post_footer > p > span#upvoted { display: none }
+
+	.desktop_item { display: none }
+	.mobile_item { display: auto }
 
 	.popup {
 		width: auto;

--- a/templates/utils.html
+++ b/templates/utils.html
@@ -164,13 +164,28 @@
     <span class="label"> Upvotes</span></div>
 	<div class="post_footer">
 		<ul id="post_links">
-			<li class="desktop_item"><a href="{{ post.permalink }}">permalink</a></li>
-			<li class="mobile_item"><a href="{{ post.permalink }}">link</a></li>
+			<li>
+				<a href="{{ post.permalink }}">
+					<span class="desktop_item">perma</span>link
+				</a>
+			</li>
 			{% if post.num_duplicates > 0 %}
-			<li class="desktop_item"><a href="/r/{{ post.community }}/duplicates/{{ post.id }}">duplicates</a></li>
-			<li class="mobile_item"><a href="/r/{{ post.community }}/duplicates/{{ post.id }}">dupes</a></li>
+			<li>
+				<a href="/r/{{ post.community }}/duplicates/{{ post.id }}">
+					dup<span class="desktop_item">licat</span>es
+				</a>
+			</li>
 			{% endif %}
 			{% call external_reddit_link(post.permalink) %}
+
+			{% if post.media.download_name != "" %}
+			<li>
+				<a href="{{ post.media.url }}" download="{{ post.media.download_name }}">
+					<span class="mobile_item">dl</span>
+					<span class="desktop_item">download</span>
+				</a>
+			</li>
+			{% endif %}
 		</ul>
 		<p>{{ post.upvote_ratio }}%<span id="upvoted"> Upvoted</span></p>
 	</div>
@@ -178,8 +193,7 @@
 {%- endmacro %}
 
 {% macro external_reddit_link(permalink) %}
-{% for dev_type in ["desktop", "mobile"] %}
-<li class="{{ dev_type }}_item">
+<li>
 	<a
 		{% if prefs.disable_visit_reddit_confirmation != "on" %}
 		href="#popup"
@@ -193,7 +207,6 @@
 		{% call visit_reddit_confirmation(permalink) %}
 	{% endif %}
 </li>
-{% endfor %}
 {% endmacro %}
 
 {% macro post_in_list(post) -%}


### PR DESCRIPTION
Resolves #66

- For video's it downloads the mp4 fallback file, not the HLS video
- I've created a 'user friendly' filename for the download using a fixed prefix (not-configurable) and the last path segment of the permalink (this should be the post title). This is because the mp4 fallback filename itself is basically just the resolution (fe 480.mp4).
- Cleaned up the desktop/mobile logic + styles

FWIW: I first looked into fixing that you cannot download the video by long pressing on the HLS player. The reason for this issue is that in `playHLSVideo.js` the player src is set to `newVideo.src = "about:blank";`

If we would change the `newVideo.src` to the mp4 url, then you could long press the player and download the video _before_ you click play. But the issue is that when you click play, then your browser will start a request for that mp4 file which is then almost immediately aborted as the HLS player is created. So adding the download link seems to be a higher level of KISS