### PR TITLE
fix: also use hls if possible for gifs in post_in_list macro

### DIFF
--- a/templates/utils.html
+++ b/templates/utils.html
@@ -262,11 +262,7 @@
 			{% endif %}
 		</a>
 	</div>
-	{% else if (prefs.layout.is_empty() || prefs.layout == "card") && post.post_type == "gif" %}
-	<div class="post_media_content">
-		<video class="post_media_video short {%if post_should_be_blurred %}post_nsfw_blur{% endif %}" src="{{ post.media.url }}" {% if post.media.width > 0 && post.media.height > 0 %}width="{{ post.media.width }}" height="{{ post.media.height }}"{% endif %} poster="{{ post.media.poster }}" preload="none" controls loop {% if prefs.autoplay_videos == "on" %}autoplay{% endif %}><a href={{ post.media.url }}>Video</a></video>
-	</div>
-	{% else if (prefs.layout.is_empty() || prefs.layout == "card") && post.post_type == "video" %}
+	{% else if (prefs.layout.is_empty() || prefs.layout == "card") && (post.post_type == "gif" || post.post_type == "video") %}
 	{% if prefs.use_hls == "on" && !post.media.alt_url.is_empty() %}
 	<div class="post_media_content">
         <video class="post_media_video short {%if post_should_be_blurred %}post_nsfw_blur{% endif %} {% if prefs.autoplay_videos == "on" %}hls_autoplay{% endif %}" {% if post.media.width > 0 && post.media.height > 0 %}width="{{ post.media.width }}" height="{{ post.media.height }}"{% endif %} poster="{{ post.media.poster }}" controls preload="none">


### PR DESCRIPTION
Posts with type gif did not play sound when being displayed in the list overview. This was caused by a difference in the utlis `post` and `post_in_list` macros, causing gif posts not being played thru hls.

The mp4 fallback_url doesn't have sound embedded btw, this is ofc also the case when downloading the mp4 file. So if hls is disabled then the gif post still doesn't have sound.