### PR TITLE
Make search bar responsive on mobile devices

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -717,7 +717,7 @@ button.submit:hover > svg { stroke: var(--accent); }
 		align-items: unset;
 	}
 
-	#search {
+	.search_widget_divider_box > #search {
 		flex: 1;
 		min-width: unset;
 		border-right: 0;
@@ -734,6 +734,10 @@ button.submit:hover > svg { stroke: var(--accent); }
 
 	.search_widget_divider_box > * {
 		width: 100%;
+	}
+
+	#sort_options {
+		min-width: fit-content;
 	}
 
 	.search_widget_divider_box > select:last-child {

--- a/static/style.css
+++ b/static/style.css
@@ -662,9 +662,12 @@ button.submit:hover > svg { stroke: var(--accent); }
 }
 
 #search_sort {
-	background: var(--highlighted);
 	border-radius: 5px;
 	overflow: auto;
+}
+
+#search_sort > * {
+	background: var(--highlighted);
 }
 
 #search_sort > #search {

--- a/static/style.css
+++ b/static/style.css
@@ -695,7 +695,7 @@ button.submit:hover > svg { stroke: var(--accent); }
 }
 
 .search_widget_divider_box > * {
-	border-right: 2px var(--background) solid;
+	border-right: 2px var(--outside) solid;
 	margin: 0;
 }
 
@@ -721,7 +721,7 @@ button.submit:hover > svg { stroke: var(--accent); }
 		flex: 1;
 		min-width: unset;
 		border-right: 0;
-		border-bottom: 2px var(--background) solid;
+		border-bottom: 2px var(--outside) solid;
 	}
 
 	#search:focus {
@@ -742,7 +742,7 @@ button.submit:hover > svg { stroke: var(--accent); }
 
 	#sort_submit {
 		height: unset;
-		border-left: 2px var(--background) solid;
+		border-left: 2px var(--outside) solid;
 	}
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -711,6 +711,41 @@ button.submit:hover > svg { stroke: var(--accent); }
 	box-shadow: none;
 }
 
+/* When screen size is smaller than 480px we switch to a design better suited for mobile devices */
+@media screen and (max-width: 480px) {
+	#search_sort {
+		align-items: unset;
+	}
+
+	#search {
+		flex: 1;
+		min-width: unset;
+		border-right: 0;
+		border-bottom: 2px var(--background) solid;
+	}
+
+	#search:focus {
+		outline: 0;
+	}
+
+	#search_sort > .search_widget_divider_box {
+		flex-wrap: wrap;
+	}
+
+	.search_widget_divider_box > * {
+		width: 100%;
+	}
+
+	.search_widget_divider_box > select:last-child {
+		border-right: 0;
+	}
+
+	#sort_submit {
+		height: unset;
+		border-left: 2px var(--background) solid;
+	}
+}
+
 #sort_options, #listing_options, main > * > footer > a {
 	border-radius: 5px;
 	align-items: center;

--- a/static/style.css
+++ b/static/style.css
@@ -652,7 +652,6 @@ button.submit:hover > svg { stroke: var(--accent); }
 }
 
 #sort_options + #timeframe:not(#search_sort > #timeframe) {
-	margin-left: 10px;
 	border-radius: 5px 0px 0px 5px;
 }
 
@@ -666,23 +665,13 @@ button.submit:hover > svg { stroke: var(--accent); }
 	overflow: auto;
 }
 
-#search_sort > * {
+#search_sort > *, .search_widget_divider_box > *, .search_widget_divider_box #sort_options {
 	background: var(--highlighted);
+	font-size: 15px;
 }
 
 #search_sort > #search {
 	border: 0;
-	background: transparent;
-}
-
-#search_sort > *, #searchbox > * { font-size: 15px; }
-
-#search_sort > :not(:first-child), #search_sort > #sort_options {
-	margin: 0;
-	border-radius: 0;
-	border-right: 0;
-	border-left: 2px solid var(--background);
-	box-shadow: none;
 	background: transparent;
 }
 
@@ -699,6 +688,27 @@ button.submit:hover > svg { stroke: var(--accent); }
 	display: flex;
 	align-items: center;
 	margin-bottom: 20px;
+}
+
+#search_sort > .search_widget_divider_box {
+	width: 100%;
+}
+
+.search_widget_divider_box > * {
+	border-right: 2px var(--background) solid;
+	margin: 0;
+}
+
+.search_widget_divider_box {
+	display: flex;
+	align-items: center;
+	max-width: 100%;
+	border: 0;
+}
+
+.search_widget_divider_box > #sort_options {
+	border-radius: 0;
+	box-shadow: none;
 }
 
 #sort_options, #listing_options, main > * > footer > a {

--- a/templates/search.html
+++ b/templates/search.html
@@ -10,25 +10,34 @@
 {% block content %}
 	<div id="column_one">
 		<form id="search_sort">
-			<input id="search" type="text" name="q" placeholder="Search" value="{{ params.q|safe }}" title="Search redlib">
-			{% if sub != "" %}
-			<div id="inside">
-				<input type="checkbox" name="restrict_sr" id="restrict_sr" {% if params.restrict_sr != "" %}checked{% endif %}>
-				<label for="restrict_sr" class="search_label">in r/{{ sub }}</label>
+			<div class="search_widget_divider_box">
+				<input id="search" type="text" name="q" placeholder="Search" value="{{ params.q|safe }}" title="Search redlib">
+				<div class="search_widget_divider_box">
+					{% if sub != "" %}
+					<div id="inside">
+						<input type="checkbox" name="restrict_sr" id="restrict_sr" {% if params.restrict_sr != "" %}checked{% endif %}>
+						<label for="restrict_sr" class="search_label">in r/{{ sub }}</label>
+					</div>
+					{% endif %}
+					{% if params.typed == "sr_user" %}<input type="hidden" name="type" value="sr_user">{% endif %}
+					<select id="sort_options" name="sort" title="Sort results by">
+						{% call utils::options(params.sort, ["relevance", "hot", "top", "new", "comments"], "") %}
+					</select>
+					{% if params.sort != "new" %}
+					<select id="timeframe" name="t" title="Timeframe"> 
+						{% call utils::options(params.t, ["hour", "day", "week", "month", "year", "all"], "all") %}
+					</select>
+					{% endif %}
+				</div>
 			</div>
-			{% endif %}
-			{% if params.typed == "sr_user" %}<input type="hidden" name="type" value="sr_user">{% endif %}
-			<select id="sort_options" name="sort" title="Sort results by">
-				{% call utils::options(params.sort, ["relevance", "hot", "top", "new", "comments"], "") %}
-			</select>{% if params.sort != "new" %}<select id="timeframe" name="t" title="Timeframe"> 
-				{% call utils::options(params.t, ["hour", "day", "week", "month", "year", "all"], "all") %}
-			</select>{% endif %}<button id="sort_submit" class="submit">
-					<svg width="15" viewBox="0 0 110 100" fill="none" stroke-width="10" stroke-linecap="round">
-						<path d="M20 50 H100" />
-						<path d="M75 15 L100 50 L75 85" />
-						&rarr;
-					</svg>
-				</button>
+
+			<button id="sort_submit" class="submit">
+				<svg width="15" viewBox="0 0 110 100" fill="none" stroke-width="10" stroke-linecap="round">
+					<path d="M20 50 H100" />
+					<path d="M75 15 L100 50 L75 85" />
+					&rarr;
+				</svg>
+			</button>
  		</form>
 
 		{% if !is_filtered %}


### PR DESCRIPTION
Closes #143 

This PR makes the search bar responsive and in turn usable on mobile devices. 

On screens whose width is lower than 480px the search bar's design will become:
![small screens](https://github.com/redlib-org/redlib/assets/70992037/522964f3-8c78-4030-8a5d-7d848250dcdd)
