### PR TITLE
Improve post information widget of user comments for devices under 480px width 

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1346,6 +1346,15 @@ summary.comment_data {
 	cursor: pointer;
 }
 
+.user_comment_data_divider {
+	display: flex;
+	align-items: center;
+}
+
+.user_comment_data_divider .dot {
+	display: none;
+}
+
 .moderator, .admin { opacity: 1; }
 .op, .moderator, .admin { font-weight: bold; }
 
@@ -1758,8 +1767,23 @@ td, th {
 	.comment_right { padding: 5px 0 10px 2px; }
 	.comment_author { margin-left: 12px; }
 	.comment_data { margin-left: 12px; }
+
+	.user-comment .comment_data {
+		flex-direction: column;
+		flex-wrap: wrap;
+		row-gap: 5px;
+	}
+
 	.comment_data::marker { font-size: 25px; }
-	.created { width: 100%; }
+	.user-comment .comment_data > .comment_link { order: 2 }
+	.user_comment_data_divider { order: 1; }
+
+	.user_comment_data_divider .dot {
+		display: unset;
+		margin-left: 5px;
+	}
+
+	.created-in { display: none; }
 
 	.comment_score {
 		min-width: 32px;

--- a/static/style.css
+++ b/static/style.css
@@ -1233,10 +1233,6 @@ a.search_subreddit:hover {
 	font-weight: bold;
 }
 
-.comment_subreddit {
-	font-weight: bold;
-}
-
 .comment_score {
 	color: var(--accent);
 	background: var(--foreground);

--- a/templates/user.html
+++ b/templates/user.html
@@ -50,7 +50,7 @@
 			{% else if !post.title.is_empty() %}
 			{% call utils::post_in_list(post) %}
 			{% else %}
-			<div class="comment">
+			<div class="comment user-comment">
 				<div class="comment_left">
 					<p class="comment_score" title="{{ post.score.1 }}">
                     {% if prefs.hide_score != "on" %}
@@ -65,8 +65,9 @@
 					<summary class="comment_data">
                         <a class="comment_link" href="{{ post.permalink }}" title="{{ post.link_title }}">{{ post.link_title }}</a>
 						<div class="user_comment_data_divider">
-							<span class="created">&nbsp;in&nbsp;</span>
-							<a href="/r/{{ post.community }}">r/{{ post.community }}</a>
+							<span class="created-in">&nbsp;in&nbsp;</span>
+							<a class="comment_subreddit" href="/r/{{ post.community }}">r/{{ post.community }}</a>
+							<span class="dot">&bull;</span>
 							<span class="created" title="{{ post.created }}">&nbsp;{{ post.rel_time }}</span>
 						</div>
 					</summary>

--- a/templates/user.html
+++ b/templates/user.html
@@ -64,9 +64,11 @@
 				<details class="comment_right" open>
 					<summary class="comment_data">
                         <a class="comment_link" href="{{ post.permalink }}" title="{{ post.link_title }}">{{ post.link_title }}</a>
-                        <span class="created">&nbsp;in&nbsp;</span>
-                        <a href="/r/{{ post.community }}">r/{{ post.community }}</a>
-                        <span class="created" title="{{ post.created }}">&nbsp;{{ post.rel_time }}</span>
+						<div class="user_comment_data_divider">
+							<span class="created">&nbsp;in&nbsp;</span>
+							<a href="/r/{{ post.community }}">r/{{ post.community }}</a>
+							<span class="created" title="{{ post.created }}">&nbsp;{{ post.rel_time }}</span>
+						</div>
 					</summary>
 					<p class="comment_body">{{ post.body|safe }}</p>
 				</details>


### PR DESCRIPTION
Fixes #180

Before:
![before](https://github.com/user-attachments/assets/07e18c38-9aed-4b91-9ff9-0410ec07d6a5)

After:
![post title](https://github.com/user-attachments/assets/5f485233-73df-45fd-af02-71fd04eb4371)

The UI remains unchanged when screen width is greater than 480px