### PR TITLE
Fix font sizes in search bar being incorrect

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -667,6 +667,8 @@ select {
     cursor: pointer;
 }
 
+#searchbox > * { font-size: 15px; }
+
 select,
 #search {
     border: none;


### PR DESCRIPTION
This pull request just readds `#searchbox > * { font-size: 15px; }` in order to set the font size of the searchbox text.

It looks like this bug was introduced in https://github.com/redlib-org/redlib/commit/410872d988c029373e614ad56c20615a75565740 when `#search_sort > *, #searchbox > * { font-size: 15px; }` was removed.

When that happened it made the subreddit name inherit the 20px font size of the navbar instead of having 15px font size like before, and I'm not sure where the placeholder "search" text (and whatever was inputted there) was inheriting it's font size from since it wasn't the 20px, but this corrects it to be 15px again as well.

Current latest commit (https://github.com/redlib-org/redlib/commit/4205959adeed9ed581b41c27f0cdb15609950316 at time of posting):
![Screenshot_20240724_185319](https://github.com/user-attachments/assets/4035e143-dbdb-44c2-9a06-5e74ede7d61d)

This pull request:
![Screenshot_20240724_185422](https://github.com/user-attachments/assets/40483831-b116-459c-8aa6-03580aa8eda3)