### PR TITLE
Fix sort options overflow on small screens

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -829,10 +829,6 @@ button.submit:hover > svg {
         width: 100%;
     }
 
-    #sort_options {
-        min-width: fit-content;
-    }
-
     .search_widget_divider_box > select:last-child {
         border-right: 0;
     }


### PR DESCRIPTION
This just removes a problematic option added in https://github.com/redlib-org/redlib/commit/410872d988c029373e614ad56c20615a75565740

Current commit:
![Screenshot_20240725_150600](https://github.com/user-attachments/assets/455dc0b0-1d0f-4202-a571-028038de66d0)

This pull request (you can scroll side to side on the sort options):
![Screenshot_20240725_150641](https://github.com/user-attachments/assets/4b2227cb-8559-45fb-a330-69ec2524d2ed)
