### PR TITLE
Fix a whole bunch of styling bugs

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -137,7 +137,6 @@ input {
     margin: 0;
     color: var(--text);
     font-family: "Inter", sans-serif;
-    word-wrap: anywhere;
 }
 
 html.fixed_navbar {

--- a/static/style.css
+++ b/static/style.css
@@ -706,6 +706,7 @@ select,
 }
 @media screen and (max-width: 800px) {
     #search { width: 0; }
+    #search.commentQuery { width: unset; }
 }
 
 #inside {
@@ -1261,6 +1262,7 @@ a.search_subreddit:hover {
 #comment_count {
     font-weight: 500;
     opacity: 0.9;
+    align-self: center;
 }
 
 #comment_count > #sorted_by {
@@ -1945,7 +1947,10 @@ th {
         #subreddit { margin: 49px 0 0; }
         #user { margin: 49px 0 20px 0; }
         #search_sort { margin-top: 11px; }
+        #settings { margin-top: 40px; }
+        div.post.highlighted { margin-top: 49px; }
         main:not(:has(div + aside)) { #sort { margin-top: 49px; } }
+        #column_one:has(div.post.highlighted + #commentQueryForms) { #sort { margin-top: 0 } }
     }
 
     #sidebar {

--- a/static/style.css
+++ b/static/style.css
@@ -1955,7 +1955,6 @@ th {
         padding-top: 45px;
         #subreddit { margin: 49px 0 0; }
         #user { margin: 49px 0 20px 0; }
-        //#search_sort { margin-top: 11px; }
         #settings { margin-top: 48px; }
         div.post.highlighted { margin-top: 49px; }
         main:not(:has(div + aside)) { #sort { margin-top: 49px; } }

--- a/static/style.css
+++ b/static/style.css
@@ -1286,7 +1286,7 @@ a.search_subreddit:hover {
     display: auto;
 }
 
-@media screen and (min-width: 481px) {
+@media screen and (min-width: 508px) {
     .mobile_item {
         display: none;
     }
@@ -1965,14 +1965,14 @@ th {
     }
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 580px) {
     #commentQueryForms {
         display: initial;
         justify-content: initial;
     }
 }
 
-@media screen and (max-width: 480px) {
+@media screen and (max-width: 507px) {
     #version {
         display: none;
     }

--- a/static/style.css
+++ b/static/style.css
@@ -137,6 +137,7 @@ input {
     margin: 0;
     color: var(--text);
     font-family: "Inter", sans-serif;
+    word-wrap: anywhere;
 }
 
 html.fixed_navbar {
@@ -862,6 +863,7 @@ main > * > footer > a {
     text-align: center;
     cursor: pointer;
     transition: 0.2s background;
+    word-wrap: normal;
 }
 
 #sort_options > a.selected,

--- a/static/style.css
+++ b/static/style.css
@@ -699,8 +699,10 @@ select,
 
 #search {
     border-right: 2px var(--outside) solid;
-    width: 0;
     flex-grow: 1;
+}
+@media screen and (max-width: 800px) {
+    #search { width: 0; }
 }
 
 #inside {

--- a/static/style.css
+++ b/static/style.css
@@ -2066,11 +2066,12 @@ th {
     }
 
     .comment_score {
-        min-width: 32px;
+        min-width: 34px;
         height: 20px;
-        font-size: 15px;
+        font-size: 12px;
         padding: 7px 0px;
         margin-right: -5px;
+        align-content: center;
     }
 
     #post_links > li {

--- a/static/style.css
+++ b/static/style.css
@@ -358,7 +358,6 @@ main {
 
 #column_one {
     width: 100%;
-    max-width: 750px;
     border-radius: 5px;
     overflow: inherit;
 }
@@ -1893,9 +1892,9 @@ th {
 /* Mobile */
 
 @media screen and (max-width: 800px) {
-    body.fixed_navbar {
-        padding-top: 120px;
-    }
+    
+    
+    
 
     main {
         flex-direction: column-reverse;
@@ -1940,8 +1939,15 @@ th {
         margin: 0;
         max-width: 100%;
     }
+    #user { margin: 0 0 20px; }
+    
+    body.fixed_navbar {
+        #subreddit { margin: 49px 0 0; }
+        #user { margin: 49px 0 20px 0; }
+        #search_sort { margin-top: 11px; }
+        main:not(:has(div + aside)) { #sort { margin-top: 49px; } }
+    }
 
-    #user,
     #sidebar {
         margin: 20px 0;
     }
@@ -1955,9 +1961,6 @@ th {
 }
 
 @media screen and (max-width: 480px) {
-    body.fixed_navbar {
-        padding-top: 100px;
-    }
     #version {
         display: none;
     }

--- a/static/style.css
+++ b/static/style.css
@@ -694,6 +694,7 @@ select,
     display: flex;
     box-shadow: var(--shadow);
     border-radius: 5px;
+    margin-bottom: 0;
 }
 
 #searchbox > *,
@@ -1912,7 +1913,7 @@ th {
     nav {
         display: grid;
         grid-template-areas: "logo links" "searchbox searchbox";
-        padding: 10px;
+        padding: 5px 10px 0;
         width: calc(100% - 20px);
     }
 
@@ -1967,6 +1968,7 @@ th {
     }
     #searchbox {
         width: calc(100vw - 20px);
+        margin-bottom: 10px;
     }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -1965,6 +1965,13 @@ th {
     }
 }
 
+@media screen and (max-width: 600px) {
+    #commentQueryForms {
+        display: initial;
+        justify-content: initial;
+    }
+}
+
 @media screen and (max-width: 480px) {
     #version {
         display: none;
@@ -2086,11 +2093,6 @@ th {
 
     .popup-inner {
         max-width: 80%;
-    }
-
-    #commentQueryForms {
-        display: initial;
-        justify-content: initial;
     }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -379,14 +379,13 @@ body > footer {
     bottom: 0;
 }
 
-.footer-button {
+.footer-buttons {
     align-items: center;
     border-radius: 0.25rem;
     box-sizing: border-box;
     color: var(--text);
     cursor: pointer;
     display: inline-flex;
-    padding-left: 1em;
     opacity: 0.8;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -167,10 +167,8 @@ body.fixed_navbar {
 }
 
 nav {
-    display: grid;
-    grid-template-areas: "logo searchbox links";
+    display: flex;
 
-    justify-content: space-between;
     align-items: center;
 
     color: var(--accent);
@@ -203,15 +201,18 @@ nav #code > svg {
 }
 
 nav #logo {
-    grid-area: logo;
     white-space: nowrap;
     margin-right: 5px;
+    flex-grow: 1;
+    flex-basis: 0;
 }
 
 nav #links {
-    grid-area: links;
     margin-left: 10px;
     display: flex;
+    flex-grow: 1;
+    flex-basis: 0;
+    justify-content: flex-end;
 }
 
 nav #links svg {
@@ -1907,6 +1908,7 @@ th {
     }
 
     nav {
+        display: grid;
         grid-template-areas: "logo links" "searchbox searchbox";
         padding: 10px;
         width: calc(100% - 20px);

--- a/static/style.css
+++ b/static/style.css
@@ -137,6 +137,7 @@ input {
     margin: 0;
     color: var(--text);
     font-family: "Inter", sans-serif;
+    word-wrap: anywhere;
 }
 
 html.fixed_navbar {

--- a/static/style.css
+++ b/static/style.css
@@ -1041,6 +1041,8 @@ a.search_subreddit:hover {
     border-radius: 5px;
     font-size: 12px;
     font-weight: bold;
+    vertical-align: text-top;
+    line-height: 1.6;
 }
 
 .awards {

--- a/static/style.css
+++ b/static/style.css
@@ -1915,6 +1915,7 @@ th {
         grid-template-areas: "logo links" "searchbox searchbox";
         padding: 5px 10px 0;
         width: calc(100% - 20px);
+        margin: 0;
     }
 
     nav #links {
@@ -1950,10 +1951,12 @@ th {
     #user { margin: 0 0 20px; }
     
     body.fixed_navbar {
+        min-height: calc(100vh - 75px);
+        padding-top: 45px;
         #subreddit { margin: 49px 0 0; }
         #user { margin: 49px 0 20px 0; }
-        #search_sort { margin-top: 11px; }
-        #settings { margin-top: 40px; }
+        //#search_sort { margin-top: 11px; }
+        #settings { margin-top: 48px; }
         div.post.highlighted { margin-top: 49px; }
         main:not(:has(div + aside)) { #sort { margin-top: 49px; } }
         #column_one:has(div.post.highlighted + #commentQueryForms) { #sort { margin-top: 0 } }

--- a/static/style.css
+++ b/static/style.css
@@ -1892,10 +1892,6 @@ th {
 /* Mobile */
 
 @media screen and (max-width: 800px) {
-    
-    
-    
-
     main {
         flex-direction: column-reverse;
         padding: 10px;

--- a/static/style.css
+++ b/static/style.css
@@ -359,7 +359,11 @@ main {
 #column_one {
     width: 100%;
     border-radius: 5px;
+    max-width: 750px;
     overflow: inherit;
+}
+@media screen and (max-width: 800px) {
+    #column_one { max-width: unset; }
 }
 
 /* Body footer. */

--- a/static/style.css
+++ b/static/style.css
@@ -458,9 +458,8 @@ aside {
     border-radius: 5px;
     overflow: hidden;
 }
-#subreddit,
-#sidebar {
-    min-width: 350px;
+@media screen and (min-width: 800px) {
+    #subreddit, #sidebar { min-width: 350px; }
 }
 
 #user *,
@@ -522,7 +521,9 @@ aside {
 #user_actions {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    grid-column-gap: 20px;
+}
+@media screen and (max-width: 279px) {
+    #sub_actions { display: unset; }
 }
 
 #user_details > label,
@@ -698,7 +699,7 @@ select,
 
 #search {
     border-right: 2px var(--outside) solid;
-    min-width: 0;
+    width: 0;
     flex-grow: 1;
 }
 
@@ -779,7 +780,7 @@ button.submit:hover > svg {
 #sort,
 #search_sort {
     display: flex;
-    align-items: center;
+    align-items: stretch;
     margin-bottom: 20px;
 }
 
@@ -806,10 +807,6 @@ button.submit:hover > svg {
 
 /* When screen size is smaller than 480px we switch to a design better suited for mobile devices */
 @media screen and (max-width: 480px) {
-    #search_sort {
-        align-items: unset;
-    }
-
     .search_widget_divider_box > #search {
         flex: 1;
         min-width: unset;
@@ -834,7 +831,7 @@ button.submit:hover > svg {
     }
 
     #sort_submit {
-        height: unset;
+        height: auto;
         border-left: 2px var(--outside) solid;
     }
 }
@@ -1951,7 +1948,7 @@ th {
         margin-bottom: 5px;
     }
     #searchbox {
-        width: calc(100vw - 35px);
+        width: calc(100vw - 20px);
     }
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -71,12 +71,8 @@
 		<!-- FOOTER -->
 		{% block footer %}
 			<footer>
-				<p id="version">v{{ env!("CARGO_PKG_VERSION") }}</p>
-				<div class="footer-button">
-					<a href="/info" title="View instance information">ⓘ View instance info</a>
-				</div>
-				<div class="footer-button">
-					<a href="https://github.com/redlib-org/redlib" title="View code on GitHub">&lt;&gt; Code</a>
+				<div class="footer-buttons">
+					<p><span id="version">v{{ env!("CARGO_PKG_VERSION") }}&emsp;</span><a href="/info" title="View instance information">ⓘ View instance info</a>&emsp;<a href="https://github.com/redlib-org/redlib" title="View code on GitHub">&lt;&gt; Code</a></p>
 				</div>
 			</footer>
 		{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -3,6 +3,10 @@
 
 {% block title %}Redlib Settings{% endblock %}
 
+{% block subscriptions %}
+	{% call utils::sub_list("") %}
+{% endblock %}
+
 {% block search %}
 	{% call utils::search("".to_owned(), "") %}
 {% endblock %}

--- a/templates/utils.html
+++ b/templates/utils.html
@@ -87,12 +87,12 @@
 		{% endif %}
 	</p>
 	<h1 class="post_title">
-		{{ post.title }}
 		{% if post.flair.flair_parts.len() > 0 %}
 			<a href="/r/{{ post.community }}/search?q=flair_name%3A%22{{ post.flair.text }}%22&restrict_sr=on"
 				class="post_flair"
 				style="color:{{ post.flair.foreground_color }}; background:{{ post.flair.background_color }};">{% call render_flair(post.flair.flair_parts) %}</a>
 		{% endif %}
+		{{ post.title }}
 		{% if post.flags.nsfw %} <small class="nsfw">NSFW</small>{% endif %}
 		{% if post.flags.spoiler %} <small class="spoiler">Spoiler</small>{% endif %}
 	</h1>


### PR DESCRIPTION
In no particular order this fixes:
- Subreddit info overflowing on very small screens
- Posts having an odd right side gap shortly before swapping to the mobile layout
- The searchbox having a small gap on the right at and below 800px
- The sort submit button on user profile being too short at and below 480px (new bug introduced in 410872d988c029373e614ad56c20615a75565740)
- The search bar becoming scrollable slightly before swapping to the new mobile layout (new bug introduced in 410872d988c029373e614ad56c20615a75565740)
- Fixed and unfixed navbar options having differently spaces gaps between the content and the navbar
- Up/downvote numbers overflowing their container when in the extra small mobile layout
-  redlib-org#172
- Search box being slightly skewed offcenter
- Post flair not lining up with title text
- Post flair position being inconsistent between feed and inside of post (in the feed it was before the title, in the post it was after, now it appears in front in both)
- Slight vertical misalignments with text in the footer
- The footer text being off center in mobile mode
- The feeds button not appearing on the settings page, changing the size of the header
- Extra navbar padding on search page

It also removes an unused option for the mobile layout below 480px.

~~I plan on trying to tackle the odd gaps some pages have when the fixed navbar is enabled but it was becoming to chaotic to try and manage adding these on top of adding that.~~ Added!
