### PR TITLE
fix: only autoplay videos if visible

### DIFF
--- a/static/playHLSVideo.js
+++ b/static/playHLSVideo.js
@@ -94,10 +94,21 @@
                 videoElement.parentNode.appendChild(qualitySelector);
             }
 
+            // IntersectionObserver to autoplay/pause video based on visibility
+            var autoplayObserver = new IntersectionObserver(function(entries) {
+                entries.forEach(function(entry) {
+                    if (entry.isIntersecting) {
+                        newVideo.play();
+                    } else {
+                        newVideo.pause();
+                    }
+                });
+            }, { threshold: 0.5 }); // Adjust the threshold as needed
+
             newVideo.addEventListener('play', initializeHls);
 
             if (autoplay) {
-                newVideo.play();
+                autoplayObserver.observe(newVideo);
             }
         });
     } else {


### PR DESCRIPTION
If autoplay is enabled, redlib will start playing all videos on the current page, at the same time. 

This introduces an observer to only start autoplaying a video if it's visible, and pause it if it stops being visible. This was my expected behavior when I enabled the "autoplay" setting.