### PR TITLE
fix: spoiler hover and video size

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1104,7 +1104,7 @@ a.search_subreddit:hover {
 
 .post_media_video {
     min-width: 100px;
-	max-width: 100px;
+    max-width: 100px;
     width: auto;
     height: auto;
     max-width: 100%;

--- a/static/style.css
+++ b/static/style.css
@@ -1103,6 +1103,8 @@ a.search_subreddit:hover {
 }
 
 .post_media_video {
+    min-width: 100px;
+	max-width: 100px;
     width: auto;
     height: auto;
     max-width: 100%;

--- a/static/style.css
+++ b/static/style.css
@@ -1121,9 +1121,7 @@ a.search_subreddit:hover {
     margin: auto;
 }
 
-.post_blurred img,
-.post_blurred svg,
-.post_blurred video {
+.post_blurred .post_media_content * {
     filter: blur(1.5rem);
 }
 
@@ -1131,16 +1129,16 @@ a.search_subreddit:hover {
     filter: blur(0.25rem);
 }
 
-.post_blurred .post_thumbnail svg {
+.post_blurred .post_thumbnail * {
     filter: blur(0.3rem);
 }
 
-.post_blurred img:hover,
-.post_blurred svg:hover,
-.post_blurred video:hover,
+.post_blurred .post_media_content:hover *,
+.post_blurred .post_media_content:hover ~ .post_body,
+.post_blurred .post_media_content:has(~ .post_body:hover) *,
 .post_blurred .post_body:hover,
-.post_blurred .post_thumbnail:hover svg {
-    filter: none;
+.post_blurred .post_thumbnail:hover * {
+	filter: none;
 }
 
 .post_media_image svg {


### PR DESCRIPTION
- Ensures that when you hover over a video spoiler, the post body is also unblurred & vice versa
- Set min size of video player for when the poster image doesn't load due to a 403 or 404 from upstream