### PR TITLE
Update license tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redlib"
 description = " Alternative private front-end to Reddit"
-license = "AGPL-3.0"
+license = "AGPL-3.0-only"
 repository = "https://github.com/redlib-org/redlib"
 version = "0.35.1"
 authors = [


### PR DESCRIPTION
Update the license tag to `AGPL-3.0-only` as `AGPL-3.0` is deprecated and ambiguous.