### PR TITLE
Add anchor to comment link

### DIFF
--- a/templates/comment.html
+++ b/templates/comment.html
@@ -24,7 +24,7 @@
 			{% if author.flair.flair_parts.len() > 0 %}
 				<small class="author_flair">{% call utils::render_flair(author.flair.flair_parts) %}</small>
 			{% endif %}
-			<a href="{{ post_link }}{{ id }}/?context=3" class="created" title="{{ created }}">{{ rel_time }}</a>
+			<a href="{{ post_link }}{{ id }}/?context=3#{{ id }}" class="created" title="{{ created }}">{{ rel_time }}</a>
 			{% if edited.0 != "".to_string() %}<span class="edited" title="{{ edited.1 }}">edited {{ edited.0 }}</span>{% endif %}
 			{% if !awards.is_empty() && prefs.hide_awards != "on" %}
 			<span class="dot">&bull;</span>


### PR DESCRIPTION
This makes it so you jump directly to the comment when you load the page. Super useful for those insanely long posts with a bunch of pictures.

Every comment already has a specific ID so I just set that as the anchor on the link.