### PR TITLE
Make jump to comment work from user's page and make last <p> in the post and comment bodies get the margin above it like the others

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1727,7 +1727,7 @@ input[type="submit"] {
     width: 100%;
 }
 
-.md > p:not(:first-child):not(:last-child) {
+.md > p:not(:first-child) {
     margin-top: 20px;
 }
 

--- a/templates/user.html
+++ b/templates/user.html
@@ -61,7 +61,7 @@ body %}
                     <summary class="comment_data">
                         <a
                             class="comment_link"
-                            href="{{ post.permalink }}"
+                            href="{{ post.permalink }}#{{ post.id }}"
                             title="{{ post.link_title }}"
                             >{{ post.link_title }}</a
                         >


### PR DESCRIPTION
https://github.com/redlib-org/redlib/pull/212 didn't work from within a user's page, this fixes that.

Also the last `<p>` item inside of the post and comment bodies didn't get the proper gap above it, leading to the last two lines of text getting squashed together. This fixes that.

This was originally intended to have more fixes in it but as I started working on them I realized a lot of the stuff I noted down didn't need fixing or wasn't feasible to fix without JS.

Was also originally supposed to go along with https://github.com/redlib-org/redlib/pull/218 but I thought that pull request was gonna be larger so it became it's own branch.