### PR TITLE
[build] add new dockerfiles for building from source

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-# supported versions here: https://github.com/rust-lang/docker-rust/tree/9f287282d513a84cb7c7f38f197838f15d37b6a9/1.81.0
+# supported versions here: https://hub.docker.com/_/rust
 ARG ALPINE_VERSION=3.20
 
 ########################

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -40,6 +40,6 @@ EXPOSE 8080
 HEALTHCHECK --interval=1m --timeout=3s CMD wget --spider --q http://localhost:8080/settings || exit 1
 
 # Add container metadata
-MAINTAINER sigaloid
+LABEL org.opencontainers.image.authors="sigaloid"
 
 CMD ["redlib"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -13,7 +13,7 @@ WORKDIR /redlib
 # download (most) dependencies in their own layer
 COPY Cargo.lock Cargo.toml ./
 RUN mkdir src && echo "fn main() { panic!(\"why am i running?\") }" > src/main.rs
-RUN cargo build --release --locked
+RUN cargo build --release --locked --bin redlib
 RUN rm ./src/main.rs && rmdir ./src
 
 # copy the source and build the redlib binary

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,49 @@
+# supported versions here: https://github.com/rust-lang/docker-rust/tree/9f287282d513a84cb7c7f38f197838f15d37b6a9/1.81.0
+ARG ALPINE_VERSION=3.20
+
+########################
+## builder image
+########################
+FROM rust:alpine${ALPINE_VERSION} AS builder
+
+RUN apk add --no-cache musl-dev
+
+WORKDIR /redlib
+
+# download (most) dependencies in their own layer
+COPY Cargo.lock Cargo.toml ./
+RUN mkdir src && echo "fn main() { panic!(\"why am i running?\") }" > src/main.rs
+RUN cargo fetch
+RUN rm ./src/main.rs && rmdir ./src
+
+# copy the source and build the redlib binary
+COPY . ./
+RUN cargo install --path .
+RUN echo "finished building redlib!"
+
+########################
+## release image
+########################
+FROM alpine:${ALPINE_VERSION} AS release
+
+# Import ca-certificates from builder
+COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+
+# Import redlib binary from builder
+COPY --from=builder /usr/local/cargo/bin/redlib /usr/local/bin/redlib
+
+# Add non-root user for running redlib
+RUN adduser --home /nonexistent --no-create-home --disabled-password redlib
+USER redlib
+
+# Document that we intend to expose port 8080 to whoever runs the container
+EXPOSE 8080
+
+# Run a healthcheck every minute to make sure redlib is functional
+HEALTHCHECK --interval=1m --timeout=3s CMD wget --spider --q http://localhost:8080/settings || exit 1
+
+# Add container metadata
+MAINTAINER sigaloid
+
+CMD ["redlib"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -13,12 +13,12 @@ WORKDIR /redlib
 # download (most) dependencies in their own layer
 COPY Cargo.lock Cargo.toml ./
 RUN mkdir src && echo "fn main() { panic!(\"why am i running?\") }" > src/main.rs
-RUN cargo fetch
+RUN cargo build --release --locked --bin redlib
 RUN rm ./src/main.rs && rmdir ./src
 
 # copy the source and build the redlib binary
 COPY . ./
-RUN cargo install --path .
+RUN cargo build --release --locked --bin redlib
 RUN echo "finished building redlib!"
 
 ########################
@@ -26,12 +26,8 @@ RUN echo "finished building redlib!"
 ########################
 FROM alpine:${ALPINE_VERSION} AS release
 
-# Import ca-certificates from builder
-COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
-
 # Import redlib binary from builder
-COPY --from=builder /usr/local/cargo/bin/redlib /usr/local/bin/redlib
+COPY --from=builder /redlib/target/release/redlib /usr/local/bin/redlib
 
 # Add non-root user for running redlib
 RUN adduser --home /nonexistent --no-create-home --disabled-password redlib

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -13,7 +13,7 @@ WORKDIR /redlib
 # download (most) dependencies in their own layer
 COPY Cargo.lock Cargo.toml ./
 RUN mkdir src && echo "fn main() { panic!(\"why am i running?\") }" > src/main.rs
-RUN cargo build --release --locked --bin redlib
+RUN cargo build --release --locked
 RUN rm ./src/main.rs && rmdir ./src
 
 # copy the source and build the redlib binary

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -12,12 +12,12 @@ WORKDIR /redlib
 # download (most) dependencies in their own layer
 COPY Cargo.lock Cargo.toml ./
 RUN mkdir src && echo "fn main() { panic!(\"why am i running?\") }" > src/main.rs
-RUN cargo fetch
+RUN cargo build --release --locked --bin redlib
 RUN rm ./src/main.rs && rmdir ./src
 
 # copy the source and build the redlib binary
 COPY . ./
-RUN cargo install --path .
+RUN cargo build --release --locked --bin redlib
 RUN echo "finished building redlib!"
 
 ########################
@@ -25,15 +25,18 @@ RUN echo "finished building redlib!"
 ########################
 FROM ubuntu:${UBUNTU_RELEASE_VERSION} AS release
 
-# Import ca-certificates from builder
-COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+# Install ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates
 
 # Import redlib binary from builder
-COPY --from=builder /usr/local/cargo/bin/redlib /usr/local/bin/redlib
+COPY --from=builder /redlib/target/release/redlib /usr/local/bin/redlib
 
 # Add non-root user for running redlib
-RUN adduser --no-create-home --disabled-password redlib
+RUN useradd \
+    --no-create-home \
+    --password "!" \
+    --comment "user for running redlib" \
+    redlib
 USER redlib
 
 # Document that we intend to expose port 8080 to whoever runs the container

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-# supported versions here: https://github.com/rust-lang/docker-rust/tree/9f287282d513a84cb7c7f38f197838f15d37b6a9/1.81.0
+# supported versions here: https://hub.docker.com/_/rust
 ARG RUST_BUILDER_VERSION=slim-bookworm
 ARG UBUNTU_RELEASE_VERSION=noble
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -12,7 +12,7 @@ WORKDIR /redlib
 # download (most) dependencies in their own layer
 COPY Cargo.lock Cargo.toml ./
 RUN mkdir src && echo "fn main() { panic!(\"why am i running?\") }" > src/main.rs
-RUN cargo build --release --locked --bin redlib
+RUN cargo build --release --locked
 RUN rm ./src/main.rs && rmdir ./src
 
 # copy the source and build the redlib binary

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 # supported versions here: https://github.com/rust-lang/docker-rust/tree/9f287282d513a84cb7c7f38f197838f15d37b6a9/1.81.0
-ARG RUST_BUILDER_VERSION=bookworm
-ARG UBUNTU_RELEASE_VERSION=jammy
+ARG RUST_BUILDER_VERSION=slim-bookworm
+ARG UBUNTU_RELEASE_VERSION=noble
 
 ########################
 ## builder image

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,0 +1,48 @@
+# supported versions here: https://github.com/rust-lang/docker-rust/tree/9f287282d513a84cb7c7f38f197838f15d37b6a9/1.81.0
+ARG RUST_BUILDER_VERSION=bookworm
+ARG UBUNTU_RELEASE_VERSION=jammy
+
+########################
+## builder image
+########################
+FROM rust:${RUST_BUILDER_VERSION} AS builder
+
+WORKDIR /redlib
+
+# download (most) dependencies in their own layer
+COPY Cargo.lock Cargo.toml ./
+RUN mkdir src && echo "fn main() { panic!(\"why am i running?\") }" > src/main.rs
+RUN cargo fetch
+RUN rm ./src/main.rs && rmdir ./src
+
+# copy the source and build the redlib binary
+COPY . ./
+RUN cargo install --path .
+RUN echo "finished building redlib!"
+
+########################
+## release image
+########################
+FROM ubuntu:${UBUNTU_RELEASE_VERSION} AS release
+
+# Import ca-certificates from builder
+COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+
+# Import redlib binary from builder
+COPY --from=builder /usr/local/cargo/bin/redlib /usr/local/bin/redlib
+
+# Add non-root user for running redlib
+RUN adduser --no-create-home --disabled-password redlib
+USER redlib
+
+# Document that we intend to expose port 8080 to whoever runs the container
+EXPOSE 8080
+
+# Run a healthcheck every minute to make sure redlib is functional
+HEALTHCHECK --interval=1m --timeout=3s CMD wget --spider --q http://localhost:8080/settings || exit 1
+
+# Add container metadata
+MAINTAINER sigaloid
+
+CMD ["redlib"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -46,6 +46,6 @@ EXPOSE 8080
 HEALTHCHECK --interval=1m --timeout=3s CMD wget --spider --q http://localhost:8080/settings || exit 1
 
 # Add container metadata
-MAINTAINER sigaloid
+LABEL org.opencontainers.image.authors="sigaloid"
 
 CMD ["redlib"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -12,7 +12,7 @@ WORKDIR /redlib
 # download (most) dependencies in their own layer
 COPY Cargo.lock Cargo.toml ./
 RUN mkdir src && echo "fn main() { panic!(\"why am i running?\") }" > src/main.rs
-RUN cargo build --release --locked
+RUN cargo build --release --locked --bin redlib
 RUN rm ./src/main.rs && rmdir ./src
 
 # copy the source and build the redlib binary


### PR DESCRIPTION
# description
this PR adds 2 new dockerfiles that allow users & developers to build containers from source in reference to [previous discussion](https://github.com/redlib-org/redlib/pull/59#issuecomment-2356608473), restoring functionality that was lost in https://github.com/redlib-org/redlib/pull/59. one issue i see people facing is that doing a docker build against a specific branch or commit unexpectedly ignores that and uses the latest release.

the original dockerfiles were:
* [Dockerfile](https://github.com/redlib-org/redlib/blob/22910956dbce2a4c8abae0016ecda251b268332c/Dockerfile)
* [Dockerfile.arm](https://github.com/redlib-org/redlib/blob/22910956dbce2a4c8abae0016ecda251b268332c/Dockerfile.arm)
* [Dockerfile.armv7](https://github.com/redlib-org/redlib/blob/22910956dbce2a4c8abae0016ecda251b268332c/Dockerfile.armv7)


they were all basically the same alpine build but used emulation to support different architectures. however we can now use the built in multi-arch support from docker. this still uses emulation but it is simpler and no longer needs specific handling in the dockerfile.

i condensed all three of those down to `Dockerfile.alpine` with small improvements & added a brand new ubuntu based `Dockerfile.ubuntu`.

i hope that we can use these to replace the current no-op dockerfile in a future PR. i have an example of releasing multi-arch builds with cross-compilation [here](https://github.com/master-hax/docker-jmusicbot/blob/465a368d5e1507dd9598fc89659eee03e8b6ebe0/.github/workflows/ci.yml).

# usage examples:

local docker build:
```
docker build . -f ./Dockerfile.alpine
docker build . -f ./Dockerfile.ubuntu
docker build . -f ./Dockerfile.alpine --build-arg ALPINE_VERSION=3.19
docker build . -f ./Dockerfile.ubuntu --build-arg UBUNTU_RELEASE_VERSION=jammy
```

local buildx build (enables cross-compilation and multi-arch containers):
```
docker buildx build --platform linux/amd64,linux/arm64 . -f ./Dockerfile.alpine
docker buildx build --platform linux/amd64 . -f ./Dockerfile.ubuntu
docker buildx build --platform linux/arm64 . -f ./Dockerfile.alpine --build-arg ALPINE_VERSION=3.19
docker buildx build --platform linux/amd64,linux/arm64 . -f ./Dockerfile.ubuntu --build-arg UBUNTU_RELEASE_VERSION=jammy
```

compose file from remote source:
```
services:
  redlib:
    build:
      context: https://github.com/redlib-org/redlib.git
      dockerfile: Dockerfile.alpine
```

```
services:
  redlib:
    build:
      context: https://github.com/redlib-org/redlib.git#v0.31.2
      dockerfile: Dockerfile.ubuntu
      args:
        UBUNTU_RELEASE_VERSION: "jammy"
```

compose file from local source (best for development):
```
services:
  redlib:
    build:
      context: ~/git/redlib
      dockerfile: Dockerfile.ubuntu
```

```
services:
  redlib:
    build:
      context: "$PWD"
      dockerfile: Dockerfile.alpine
      args:
        ALPINE_VERSION: "3.20"
```