### PR TITLE
fix: gracefully shutdown on CTRL+C and SIGTERM on Linux

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -267,8 +267,19 @@ impl Server {
 
 		// Bind server to address specified above. Gracefully shut down if CTRL+C is pressed
 		let server = HyperServer::bind(address).serve(make_svc).with_graceful_shutdown(async {
+			#[cfg(windows)]
 			// Wait for the CTRL+C signal
 			tokio::signal::ctrl_c().await.expect("Failed to install CTRL+C signal handler");
+
+			#[cfg(unix)]
+			{
+				// Wait for CTRL+C or SIGTERM signals
+				let mut signal_terminate = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).expect("Failed to install SIGTERM signal handler");
+				tokio::select! {
+					_ = tokio::signal::ctrl_c() => (),
+					_ = signal_terminate.recv() => ()
+				}
+			}
 		});
 
 		server.boxed()


### PR DESCRIPTION
When running on Linux, listen for SIGTERM in addition to CTRL+C.

I am not incredibly competent with Rust and Linux is my daily driver, so please double-check my changes. Regardless, this should behave relatively the same on Linux and Windows, past the "Failed to install CTRL+C signal handler" error not appearing on Linux if redlib fails to install that signal handler.

This also fixes #205.