### PR TITLE
Change the text logo to image

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -220,7 +220,12 @@ nav #links svg {
 }
 
 nav #redlib {
-    vertical-align: -2px;
+    margin-right: 10px;
+}
+
+nav #redlib img {
+    width: 38px;
+    vertical-align: middle;
 }
 
 figcaption {

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,7 +38,7 @@
 		<nav class="
 			{% if prefs.fixed_navbar == "on" %} fixed_navbar{% endif %}">
 			<div id="logo">
-				<a id="redlib" href="/"><span id="lib">red</span><span id="reddit">lib.</span></a>
+				<a id="redlib" href="/"><img src="/logo.png"></a>
 				{% block subscriptions %}{% endblock %}
 			</div>
 			{% block search %}{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,7 +38,7 @@
 		<nav class="
 			{% if prefs.fixed_navbar == "on" %} fixed_navbar{% endif %}">
 			<div id="logo">
-				<a id="redlib" href="/"><img src="/logo.png"></a>
+				<a id="redlib" href="/"><img src="/logo.png" alt="RedLib logo"></a>
 				{% block subscriptions %}{% endblock %}
 			</div>
 			{% block search %}{% endblock %}


### PR DESCRIPTION
This PR is for #203 , to change current text logo to `<img>` tag with the source image already existed in the source code.

The image `width` is now `38px`, a little bit bigger than `36px`. Let me know if it's okay.

It will look like this on:
Mobile:
<img width="402" alt="image" src="https://github.com/user-attachments/assets/ce06f4f7-0bbc-488f-8e3f-e464b8f1a646">

Desktop:
<img width="713" alt="image" src="https://github.com/user-attachments/assets/720ab237-41b1-4c3d-a412-8a74b36bc7bf">
