### PR TITLE
chore(deps): Update brotli from 6.0 to 7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ time = { version = "0.3.31", features = ["local-offset"] }
 url = "2.5.0"
 rust-embed = { version = "8.1.0", features = ["include-exclude"] }
 libflate = "2.0.0"
-brotli = { version = "6.0.0", features = ["std"] }
+brotli = { version = "7.0.0", features = ["std"] }
 toml = "0.8.8"
 once_cell = "1.19.0"
 serde_yaml = "0.9.29"


### PR DESCRIPTION
There were few changes between 6.0.0 and 7.0.0, and it looks like https://github.com/dropbox/rust-brotli/commit/41cadaabb6c650ae518b30509a5fbe43ca8cfab9 was the only breaking one. I confirmed that `cargo test -- --exact --skip client::test_share_link_strip_json --skip utils::test_fetching_nsfw_subreddit --skip client::test_obfuscated_share_link` still passes. (The three skipped tests already fail on `main`.)