### PR TITLE
fix: update devcontainer image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Rust",
-    "image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye",
+    "image": "mcr.microsoft.com/devcontainers/rust:1.0.9-bookworm",
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2": {}
     },


### PR DESCRIPTION
The existing config for Dev Containers doesn't work. Currently, is fails to build the project because the image uses an outdated version of rust, that is not supported by one or more dependencies.

This PR updates the used image to the most recent one and resolves the problem.