### PR TITLE
Fix embedded images sometimes having gaps around them

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -909,7 +909,7 @@ pub fn format_url(url: &str) -> String {
 
 // These are links we want to replace in-body
 static REDDIT_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r#"href="(https|http|)://(www\.|old\.|np\.|amp\.|new\.|)(reddit\.com|redd\.it)/"#).unwrap());
-static REDDIT_PREVIEW_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"https?://(external-preview|preview|i)\.redd\.it(.*)[^?]").unwrap());
+static REDDIT_PREVIEW_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"https?://(external-preview|preview|i)\.redd\.it(.*)").unwrap());
 static REDDIT_EMOJI_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"https?://(www|).redditstatic\.com/(.*)").unwrap());
 static REDLIB_PREVIEW_LINK_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r#"/(img|preview/)(pre|external-pre)?/(.*?)>"#).unwrap());
 static REDLIB_PREVIEW_TEXT_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r">(.*?)</a>").unwrap());
@@ -933,6 +933,8 @@ pub fn rewrite_urls(input_text: &str) -> String {
 
 	// Remove (html-encoded) "\" from URLs.
 	text1 = text1.replace("%5C", "").replace("\\_", "_");
+
+	println!("text1 before: {text1}");
 
 	// Rewrite external media previews to Redlib
 	loop {
@@ -1367,7 +1369,7 @@ async fn test_fetching_ws() {
 fn test_rewriting_image_links() {
 	let input =
 		r#"<p><a href="https://preview.redd.it/6awags382xo31.png?width=2560&amp;format=png&amp;auto=webp&amp;s=9c563aed4f07a91bdd249b5a3cea43a79710dcfc">caption 1</a></p>"#;
-	let output = r#"<p><figure><a href="/preview/pre/6awags382xo31.png?width=2560&amp;format=png&amp;auto=webp&amp;s=9c563aed4f07a91bdd249b5a3cea43a79710dcfc"><img loading="lazy" src="/preview/pre/6awags382xo31.png?width=2560&amp;format=png&amp;auto=webp&amp;s=9c563aed4f07a91bdd249b5a3cea43a79710dcfc"></a><figcaption>caption 1</figcaption></figure></p"#;
+	let output = r#"<figure><a href="/preview/pre/6awags382xo31.png?width=2560&amp;format=png&amp;auto=webp&amp;s=9c563aed4f07a91bdd249b5a3cea43a79710dcfc"><img loading="lazy" src="/preview/pre/6awags382xo31.png?width=2560&amp;format=png&amp;auto=webp&amp;s=9c563aed4f07a91bdd249b5a3cea43a79710dcfc"></a><figcaption>caption 1</figcaption></figure>"#;
 	assert_eq!(rewrite_urls(input), output);
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -951,7 +951,7 @@ pub fn rewrite_urls(input_text: &str) -> String {
 			}
 
 			// image_url contains > at the end of it, and right above this we remove image_text's front >, leaving us with just a single > between them
-			let image_to_replace = format!("<a href=\"{image_url}{image_caption}</a>");
+			let image_to_replace = format!("<p><a href=\"{image_url}{image_caption}</a></p>");
 
 			// _image_replacement needs to be in scope for the replacement at the bottom of the loop
 			let mut _image_replacement = String::new();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -934,8 +934,6 @@ pub fn rewrite_urls(input_text: &str) -> String {
 	// Remove (html-encoded) "\" from URLs.
 	text1 = text1.replace("%5C", "").replace("\\_", "_");
 
-	println!("text1 before: {text1}");
-
 	// Rewrite external media previews to Redlib
 	loop {
 		if REDDIT_PREVIEW_REGEX.find(&text1).is_none() {


### PR DESCRIPTION
Was caused by rewrite_urls() not replacing the original `<p>` and `</p>` surrounding the image link.

Before:
![Screenshot_20241017_200516](https://github.com/user-attachments/assets/61920ea6-2449-4b3e-aa54-809492aed5aa)

After:
![Screenshot_20241017_200520](https://github.com/user-attachments/assets/50104a23-cdd4-4123-956a-f9bc0b6b3325)