### PR TITLE
Readme: Add better instructions on building a release binary from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,14 @@ git clone https://github.com/redlib-org/redlib && cd redlib
 cargo run
 ```
 
+Note that the above command will compile a debug build with logging and run the binary automatically. Use the following command to compile a release build with no logging.
+
+```
+cargo build --release
+```
+
+The compiled release binary can be found in `target/release/redlib`.
+
 ## Replit/Heroku
 
 > [!WARNING]


### PR DESCRIPTION
Just a little update to the docs as I had to dig into the CI scripts to figure out how to build a release binary.