### PR TITLE
Use quotes for kaniko to expand ARG in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGET
 
 RUN apk add --no-cache curl
 
-RUN curl -L https://github.com/redlib-org/redlib/releases/latest/download/redlib-${TARGET}.tar.gz | \
+RUN curl -L "https://github.com/redlib-org/redlib/releases/latest/download/redlib-${TARGET}.tar.gz" | \
     tar xz -C /usr/local/bin/
 
 RUN adduser --home /nonexistent --no-create-home --disabled-password redlib


### PR DESCRIPTION
kaniko in k8s would not expand the `TARGET` arg without double quotes around it.