### PR TITLE
Add Quadlet Container File

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@
    - [Docker](#docker)
      - [Docker Compose](#docker-compose)
      - [Docker CLI](#docker-cli)
+   - Podman 
+      - Quadlets
+
    - [Binary](#binary)
      - [Running as a systemd service](#running-as-a-systemd-service)
    - [Building from source](#building-from-source)
@@ -180,7 +183,7 @@ For configuration options, see the [Configuration section](#Configuration).
 
 [Docker](https://www.docker.com) lets you run containerized applications. Containers are loosely isolated environments that are lightweight and contain everything needed to run the application, so there's no need to rely on what's installed on the host.
 
-Docker images for Redlib are available at [quay.io](https://quay.io/repository/redlib/redlib), with support for `amd64`, `arm64`, and `armv7` platforms.
+Container images for Redlib are available at [quay.io](https://quay.io/repository/redlib/redlib), with support for `amd64`, `arm64`, and `armv7` platforms.
 
 ### Docker Compose
 
@@ -223,6 +226,37 @@ Stream logs from the Redlib container:
 
 ```bash
 docker logs -f redlib
+```
+## Podman 
+
+[Podman](https://podman.io/) lets you run containerized applications in a rootless fashion. Containers are loosely isolated environments that are lightweight and contain everything needed to run the application, so there's no need to rely on what's installed on the host.
+
+Container images for Redlib are available at [quay.io](https://quay.io/repository/redlib/redlib), with support for `amd64`, `arm64`, and `armv7` platforms.
+
+### Quadlets
+
+> [!IMPORTANT]
+> These instructions assume that you are on a systemd based distro with [podman](https://podman.io/). If not, follow these [instructions on podman's website](https://podman.io/docs/installation) for how to do so. 
+> It also assumes you have used `loginctl enable-linger <username>` to enable the service to start for your user without logging in. 
+
+Copy the `redlib.container` and `.env.example` files to `.config/containers/systemd/` and modify any relevant values (for example, the ports Redlib should listen on, renaming the .env file and editing its values, etc.).
+
+To start Redlib either reboot or follow the instructions below:
+
+Notify systemd of the new files
+```bash
+systemctl --user daemon-reload
+```
+
+Start the newly generated service file
+
+```bash
+systemctl --user start redlib.service
+```
+
+You can check the status of your container by using the following command:
+```bash 
+systemctl --user status redlib.service
 ```
 
 ## Binary

--- a/redlib.container
+++ b/redlib.container
@@ -1,0 +1,16 @@
+[Install]
+WantedBy=default.target
+
+[Container]
+AutoUpdate=registry
+ContainerName=redlib
+DropCapability=ALL
+EnvironmentFile=.env
+HealthCmd=["wget","--spider","-q","--tries=1","http://localhost:8080/settings"]
+HealthInterval=5m
+HealthTimeout=3s
+Image=quay.io/redlib/redlib:latest
+NoNewPrivileges=true
+PublishPort=8080:8080
+ReadOnly=true
+User=nobody


### PR DESCRIPTION
I'm working with Quadlet files, which simplify the deployment of systemd units for Podman containers. They are similar to docker-compose, but for podman and systemd.

For those who have not used Quadlets, this file should be placed at `.config/containers/systemd/redlib.container` and would use podman and systemd to automatically start and run the container on boot for users that have `enable-linger` turned on