### PR TITLE
Implement a serialiizer for user preferences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,6 +1384,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_path",
+ "serde_urlencoded",
  "serde_yaml",
  "tegen",
  "time",
@@ -1794,6 +1795,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ async-recursion = "1.1.1"
 common-words-all = { version = "0.0.2", default-features = false, features = ["english", "one"] }
 hyper-rustls = { version = "0.24.2", features = [ "http2" ] }
 tegen = "0.1.4"
+serde_urlencoded = "0.7.1"
 
 
 [dev-dependencies]

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -161,8 +161,16 @@
 	{% endif %}
 
 	<div id="settings_note">
-		<p><b>Note:</b> settings and subscriptions are saved in browser cookies. Clearing your cookies will reset them.</p><br>
-		<p>You can restore your current settings and subscriptions after clearing your cookies using <a href="/settings/restore/?theme={{ prefs.theme }}&front_page={{ prefs.front_page }}&layout={{ prefs.layout }}&wide={{ prefs.wide }}&post_sort={{ prefs.post_sort }}&comment_sort={{ prefs.comment_sort }}&show_nsfw={{ prefs.show_nsfw }}&use_hls={{ prefs.use_hls }}&hide_hls_notification={{ prefs.hide_hls_notification }}&hide_awards={{ prefs.hide_awards }}&fixed_navbar={{ prefs.fixed_navbar }}&subscriptions={{ prefs.subscriptions.join("%2B") }}&filters={{ prefs.filters.join("%2B") }}">this link</a>.</p>
+		<p><b>Note:</b> settings and subscriptions are saved in browser cookies. Clearing your cookies will reset them.</p>
+		<br>
+		{% match prefs.to_urlencoded() %}
+		{% when Ok with (encoded_prefs) %}
+		<p>You can restore your current settings and subscriptions after clearing your cookies using <a
+				href="/settings/restore/?{{ encoded_prefs }}">this link</a>.</p>
+		{% when Err with (err) %}
+		<p>There was an error creating your restore link: {{ err }}</p>
+		<p>Please report this issue</p>
+		{% endmatch %}
 	</div>
 </div>
 


### PR DESCRIPTION
Uses `serde_urlencoded` to serialize the `Preferences` struct when creating the settings restore link. This approach unfortunately is fallible, but i can't imagine a scenario where it would fail. I also added a test for the serialization process.
Fixes #315