### PR TITLE
refactor: replace static with const for global constants

### DIFF
--- a/scripts/update_oauth_resources.sh
+++ b/scripts/update_oauth_resources.sh
@@ -24,7 +24,7 @@ echo "// Please do not edit manually" >> "$filename"
 echo "// Filled in with real app versions" >> "$filename"
 
 # Open the array in the source file
-echo "pub static _IOS_APP_VERSION_LIST: &[&str; $ios_app_count] = &[" >> "$filename"
+echo "pub const _IOS_APP_VERSION_LIST: &[&str; $ios_app_count] = &[" >> "$filename"
 
 num=0
 
@@ -63,7 +63,7 @@ android_count=$(echo "$versions" | wc -l)
 echo -e "Fetching \e[32m$android_count Android app versions...\e[0m"
 
 # Append to the source file
-echo "pub static ANDROID_APP_VERSION_LIST: &[&str; $android_count] = &[" >> "$filename"
+echo "pub const ANDROID_APP_VERSION_LIST: &[&str; $android_count] = &[" >> "$filename"
 
 num=0
 
@@ -89,7 +89,7 @@ ios_count=$(echo "$table" | wc -l)
 echo -e "Fetching \e[34m$ios_count iOS versions...\e[0m"
 
 # Append to the source file
-echo "pub static _IOS_OS_VERSION_LIST: &[&str; $ios_count] = &[" >> "$filename"
+echo "pub const _IOS_OS_VERSION_LIST: &[&str; $ios_count] = &[" >> "$filename"
 
 num=0
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -45,7 +45,7 @@ pub static OAUTH_RATELIMIT_REMAINING: AtomicU16 = AtomicU16::new(99);
 
 pub static OAUTH_IS_ROLLING_OVER: AtomicBool = AtomicBool::new(false);
 
-static URL_PAIRS: [(&str, &str); 2] = [
+const URL_PAIRS: [(&str, &str); 2] = [
 	(ALTERNATIVE_REDDIT_URL_BASE, ALTERNATIVE_REDDIT_URL_BASE_HOST),
 	(REDDIT_SHORT_URL_BASE, REDDIT_SHORT_URL_BASE_HOST),
 ];
@@ -262,7 +262,7 @@ fn request(method: &'static Method, path: String, redirect: bool, quarantine: bo
 							return Ok(response);
 						};
 						let location_header = response.headers().get(header::LOCATION);
-						if location_header == Some(&HeaderValue::from_static("https://www.reddit.com/")) {
+						if location_header == Some(&HeaderValue::from_static(ALTERNATIVE_REDDIT_URL_BASE)) {
 							return Err("Reddit response was invalid".to_string());
 						}
 						return request(
@@ -528,7 +528,7 @@ fn test_default_subscriptions() {
 }
 
 #[cfg(test)]
-static POPULAR_URL: &str = "/r/popular/hot.json?&raw_json=1&geo_filter=GLOBAL";
+const POPULAR_URL: &str = "/r/popular/hot.json?&raw_json=1&geo_filter=GLOBAL";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_localization_popular() {

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -11,9 +11,9 @@ use serde_json::json;
 use tegen::tegen::TextGenerator;
 use tokio::time::{error::Elapsed, timeout};
 
-static REDDIT_ANDROID_OAUTH_CLIENT_ID: &str = "ohXpoqrZYub1kg";
+const REDDIT_ANDROID_OAUTH_CLIENT_ID: &str = "ohXpoqrZYub1kg";
 
-static AUTH_ENDPOINT: &str = "https://www.reddit.com";
+const AUTH_ENDPOINT: &str = "https://www.reddit.com";
 
 // Spoofed client for Android devices
 #[derive(Debug, Clone, Default)]

--- a/src/oauth_resources.rs
+++ b/src/oauth_resources.rs
@@ -2,8 +2,8 @@
 // Rerun scripts/update_oauth_resources.sh to update this file
 // Please do not edit manually
 // Filled in with real app versions
-pub static _IOS_APP_VERSION_LIST: &[&str; 1] = &[""];
-pub static ANDROID_APP_VERSION_LIST: &[&str; 150] = &[
+pub const _IOS_APP_VERSION_LIST: &[&str; 1] = &[""];
+pub const ANDROID_APP_VERSION_LIST: &[&str; 150] = &[
 	"Version 2024.22.1/Build 1652272",
 	"Version 2024.23.1/Build 1665606",
 	"Version 2024.24.1/Build 1682520",
@@ -155,4 +155,4 @@ pub static ANDROID_APP_VERSION_LIST: &[&str; 150] = &[
 	"Version 2022.41.0/Build 630468",
 	"Version 2022.41.1/Build 634168",
 ];
-pub static _IOS_OS_VERSION_LIST: &[&str; 1] = &[""];
+pub const _IOS_OS_VERSION_LIST: &[&str; 1] = &[""];


### PR DESCRIPTION
- For global variables which don't need to be mutable, prefer `const` to `static`.