### PR TITLE
unescape selftext_html from json api, fixes #354

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,6 +771,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1373,7 @@ dependencies = [
  "dotenvy",
  "fastrand",
  "futures-lite",
+ "htmlescape",
  "hyper",
  "hyper-rustls",
  "libflate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ common-words-all = { version = "0.0.2", default-features = false, features = ["e
 hyper-rustls = { version = "0.24.2", features = [ "http2" ] }
 tegen = "0.1.4"
 serde_urlencoded = "0.7.1"
+htmlescape = "0.3.1"
 
 
 [dev-dependencies]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,7 @@ use crate::config::{self, get_setting};
 //
 use crate::{client::json, server::RequestExt};
 use cookie::Cookie;
+use htmlescape::decode_html;
 use hyper::{Body, Request, Response};
 use log::error;
 use once_cell::sync::Lazy;
@@ -22,7 +23,6 @@ use std::str::FromStr;
 use std::string::ToString;
 use time::{macros::format_description, Duration, OffsetDateTime};
 use url::Url;
-use htmlescape::decode_html;
 
 /// Write a message to stderr on debug mode. This function is a no-op on
 /// release code.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,6 +22,7 @@ use std::str::FromStr;
 use std::string::ToString;
 use time::{macros::format_description, Duration, OffsetDateTime};
 use url::Url;
+use htmlescape::decode_html;
 
 /// Write a message to stderr on debug mode. This function is a no-op on
 /// release code.
@@ -376,7 +377,7 @@ impl Post {
 			let awards = Awards::parse(&data["all_awardings"]);
 
 			// selftext_html is set for text posts when browsing.
-			let mut body = rewrite_urls(&val(post, "selftext_html"));
+			let mut body = rewrite_urls(&decode_html(&val(post, "selftext_html")).unwrap());
 			if body.is_empty() {
 				body = rewrite_urls(&val(post, "body_html"));
 			}


### PR DESCRIPTION
The json api at https://www.reddit.com/r/emulation/hot.json returns selftext_html as a escaped html string.

This was passed straight to the rss output, causing rendering issues.

Instead, unescape the html, which will be embedded it in rss as  `<content:encoded><![CDATA[ selftext_html ]]></content:encoded>`

Question: I am not sure it is necessary to add yet another dependency (htmlescape), maybe the functionality exists in some other already imported crate?