### PR TITLE
Support HEAD requests (resolves #292)

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -267,13 +267,13 @@ impl Server {
 
 										Ok(res)
 									}
-									Err(msg) => new_boilerplate(def_headers, req_headers, 500, Body::from(msg)).await,
+									Err(msg) => new_boilerplate(def_headers, req_headers, 500, if is_head { Body::empty() } else { Body::from(msg) }).await,
 								}
 							}
 							.boxed()
 						}
 						// If there was a routing error
-						Err(e) => new_boilerplate(def_headers, req_headers, 404, e.into()).boxed(),
+						Err(e) => new_boilerplate(def_headers, req_headers, 404, if is_head { Body::empty() } else { e.into() }).boxed(),
 					}
 				}))
 			}


### PR DESCRIPTION
This PR changes the Redlib router to call the GET handler on HEAD requests, discard the body (skipping compression) and returning only headers.

Resolves #292 