### PR TITLE
Fix: Footer at a fixed position (bottom of the screen)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -375,7 +375,7 @@ body > footer {
     align-items: center;
     width: 100%;
     background: var(--post);
-    position: absolute;
+    position: fixed;
     bottom: 0;
 }
 


### PR DESCRIPTION
Fixes redlib-org/redlib#393

I didn't build the project and test it locally right now, so I'd appreciate if someone is able to do that. I simply changed it in my browser and it look right. Here are some screenshots.

Before:
![2025-03-11-035044_972x230_scrot](https://github.com/user-attachments/assets/4e618bd5-457b-4418-b0d8-674393bd4525)

After:
![2025-03-11-035103_1010x228_scrot](https://github.com/user-attachments/assets/c364d21b-0ce8-42a9-a8ca-fa17b401474a)


