### PR TITLE
Add license links to remaining JS files

### DIFF
--- a/static/check_update.js
+++ b/static/check_update.js
@@ -1,3 +1,4 @@
+// @license http://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0
 async function checkInstanceUpdateStatus() {
     try {
         const response = await fetch('/commits.atom');
@@ -56,3 +57,4 @@ async function checkOtherInstances() {
 window.addEventListener('load', checkOtherInstances);
 
 checkInstanceUpdateStatus();
+// @license-end

--- a/static/copy.js
+++ b/static/copy.js
@@ -1,3 +1,4 @@
+// @license http://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0
 async function copy() {
     await navigator.clipboard.writeText(document.getElementById('bincode_str').value);
 }
@@ -7,3 +8,4 @@ async function set_listener() {
 }
 
 window.addEventListener('load', set_listener);
+// @license-end

--- a/static/highlighted.js
+++ b/static/highlighted.js
@@ -1,1 +1,3 @@
+// @license http://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0
 document.querySelector('#commentQueryForms').scrollIntoView();
+// @license-end


### PR DESCRIPTION
Of the 5 scripts optionally used in Redlib, 2 of them are marked with licenses that make them [LibreJS compatible](https://www.gnu.org/software/librejs/manual/html_node/Setting-Your-JavaScript-Free.html#License-tags):
1. [hls.min.js](https://github.com/redlib-org/redlib/blob/main/static/hls.min.js)
2. [playHLSVideo.js](https://github.com/redlib-org/redlib/blob/main/static/playHLSVideo.js)

This pull request adds license links for LibreJS to the remaining 3 scripts:
1. check_update.js
2. copy.js
3. highlighted.js