### PR TITLE
Fix element margins inside posts and comments

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1112,6 +1112,10 @@ pub fn rewrite_urls(input_text: &str) -> String {
 	// Remove (html-encoded) "\" from URLs.
 	text1 = text1.replace("%5C", "").replace("\\_", "_");
 
+	/* Remove paragraphs that only contain zero width spaces.
+	Reddit ignores these in their formatting so we want to remove them so they don't mess with ours. */
+	text1 = text1.replace("<p>&#8203;</p>", "").replace("<p>&#x200B;</p>", "");
+
 	// Rewrite external media previews to Redlib
 	loop {
 		if REDDIT_PREVIEW_REGEX.find(&text1).is_none() {

--- a/static/style.css
+++ b/static/style.css
@@ -1756,7 +1756,7 @@ input[type="submit"] {
 }
 
 .md > * {
-    margin-bottom: 1rem;
+    margin-bottom: 1.25rem;
 }
 
 .md h1 {
@@ -1779,7 +1779,7 @@ input[type="submit"] {
 }
 
 .md h1, h2, h3, h4, h5, h6 {
-    margin: 1rem 0 .5rem;
+    margin: 1.25rem 0 .75rem;
 }
 
 .md blockquote {

--- a/static/style.css
+++ b/static/style.css
@@ -1210,7 +1210,6 @@ a.search_subreddit:hover {
 .post_body pre {
     background: var(--background);
     overflow-x: auto;
-    margin: 10px 0;
     padding: 10px;
 }
 
@@ -1748,17 +1747,16 @@ input[type="submit"] {
     width: 100%;
 }
 
-.md > p:not(:first-child) {
-    margin-top: 20px;
+.md > :first-child {
+    margin-top: 0;
 }
 
-.md > figure:first-of-type {
-    margin-top: 5px;
-    margin-bottom: 0px;
+.md > :last-child {
+    margin-bottom: 0;
 }
 
-.md > figure:not(:first-of-type) {
-    margin-top: 10px;
+.md > * {
+    margin-bottom: 1rem;
 }
 
 .md h1 {
@@ -1778,6 +1776,10 @@ input[type="submit"] {
 }
 .md h6 {
     font-size: 12px;
+}
+
+.md h1, h2, h3, h4, h5, h6 {
+    margin: 1rem 0 .5rem;
 }
 
 .md blockquote {
@@ -1818,7 +1820,6 @@ input[type="submit"] {
 .md pre {
     background: var(--outside);
     padding: 20px;
-    margin-top: 10px;
     border-radius: 5px;
     box-shadow: var(--shadow);
     overflow: auto;


### PR DESCRIPTION
There was inconsistent margins between different types of elements, and headings had no margins at all. This fixes that.

It also removes odd paragraphs that only had a zero width space inside of them that could add large gaps between items. Not really sure if these are user placed or not, but somehow Reddit is able to have the margins on these not interrupt their formatting so I figured it's best to remove them. The code for this is just inside of `rewrite_urls()` because I couldn't find a better spot for it but that definitely doesn't fit the name of the function so suggestions on a better place are certainly welcome.

Screenshots below from: /r/linux/comments/1k2ilrt/configuring_persistent_network_routing_and/

Before:
![Screenshot_20250419_151302](https://github.com/user-attachments/assets/1205840b-dc4a-4bb0-aa2e-57865d686c3b)

After:
![Screenshot_20250419_151330](https://github.com/user-attachments/assets/3be10f98-aa5b-4b76-bff8-fb8fa24639c2)
