### PR TITLE
fix: update devcontainer image (redlib-org#434)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Rust",
-    "image": "mcr.microsoft.com/devcontainers/rust:1.0.9-bookworm",
+    "image": "mcr.microsoft.com/devcontainers/rust:1.0.23-bookworm",
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2": {}
     },


### PR DESCRIPTION
This PR fixes #434 by updating the devcontainer configuration to use the `mcr.microsoft.com/devcontainers/rust:1.0.23-bookworm` docker image.