### PR TITLE
fix: avoid redirecting to undefined instance

### DIFF
--- a/static/check_update.js
+++ b/static/check_update.js
@@ -41,8 +41,10 @@ async function checkOtherInstances() {
     try {
         const response = await fetch('/instances.json');
         const data = await response.json();
-        const randomInstance = data.instances[Math.floor(Math.random() * data.instances.length)];
-        const instanceUrl = randomInstance.url;
+        const instances = window.location.host.endsWith('.onion') ? data.instances.filter(i => i.onion) : data.instances.filter(i => i.url);
+        if (instances.length == 0) return;
+        const randomInstance = instances[Math.floor(Math.random() * instances.length)];
+        const instanceUrl = randomInstance.url ?? randomInstance.onion;
         // Set the href of the <a> tag to the instance URL with path included
         document.getElementById('random-instance').href = instanceUrl + window.location.pathname;
         document.getElementById('random-instance').innerText = "Visit Random Instance";


### PR DESCRIPTION
Since there's an onion instance in the list without a `url` value, occasionally the redirect gives `undefined` as instance domain. This avoids it for clearnet users.

For users on an onion domain this will return only onion instances, though this might not be the most appropriate choice right now given that there is only one onion instance...