### PR TITLE
Add support for HTTP_PROXY and SOCKS_PROXY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1403,7 @@ dependencies = [
  "tegen",
  "time",
  "tokio",
+ "tokio-socks",
  "toml",
  "url",
  "uuid",
@@ -2092,6 +2099,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ htmlescape = "0.3.1"
 bincode = "1.3.3"
 base2048 = "2.0.2"
 revision = "0.10.0"
+tokio-socks = "0.5.2"
 
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,4 @@ pub mod settings;
 pub mod subreddit;
 pub mod user;
 pub mod utils;
+mod proxy;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,0 +1,164 @@
+use hyper::client::HttpConnector;
+use hyper::service::Service;
+use hyper::Uri;
+use std::env;
+use std::error::Error;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::net::TcpStream;
+use tokio_socks::tcp::Socks5Stream;
+use log::debug;
+use std::fmt;
+use base64::Engine;
+use base64::engine::general_purpose;
+
+#[derive(Clone)]
+pub enum ProxyConnector {
+    NoProxy(HttpConnector),
+    Socks(String),
+    Http(String),
+}
+
+#[derive(Debug)]
+pub struct ProxyError(String);
+
+impl fmt::Display for ProxyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Proxy error: {}", self.0)
+    }
+}
+
+impl Error for ProxyError {}
+
+impl Service<Uri> for ProxyConnector {
+    type Response = TcpStream;
+    type Error = Box<dyn Error + Send + Sync>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        match self {
+            ProxyConnector::NoProxy(connector) => connector.poll_ready(cx).map_err(Into::into),
+            _ => Poll::Ready(Ok(()))
+        }
+    }
+
+    fn call(&mut self, uri: Uri) -> Self::Future {
+        let this = self.clone();
+        Box::pin(async move {
+            match this {
+                ProxyConnector::NoProxy(mut connector) => {
+                    let stream = connector.call(uri).await.map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)?;
+                    Ok(stream)
+                }
+                ProxyConnector::Socks(proxy_addr) => {
+                    let (host, port, credentials) = parse_proxy_addr(&proxy_addr)?;
+                    let target_addr = get_target_addr(&uri)?;
+
+                    let stream = match credentials {
+                        Some((username, password)) => {
+                            Socks5Stream::connect_with_password(
+                                (host.as_str(), port),
+                                target_addr,
+                                &username,
+                                &password
+                            ).await
+                        },
+                        None => {
+                            Socks5Stream::connect(
+                                (host.as_str(), port),
+                                target_addr
+                            ).await
+                        }
+                    }.map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)?;
+
+                    Ok(stream.into_inner())
+
+                }
+                ProxyConnector::Http(proxy_addr) => {
+                    let (host, port, credentials) = parse_proxy_addr(&proxy_addr)?;
+                    let proxy_stream = TcpStream::connect((host.as_str(), port)).await.map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)?;
+
+                    let target_addr = get_target_addr(&uri)?;
+                    let mut connect_req = format!(
+                        "CONNECT {target_addr} HTTP/1.1\r\n\
+                         Host: {target_addr}\r\n\
+                         Connection: keep-alive\r\n"
+                    );
+
+                    if let Some((username, password)) = credentials {
+                        let auth = general_purpose::STANDARD.encode(format!("{}:{}", username, password));
+                        connect_req.push_str(&format!("Proxy-Authorization: Basic {}\r\n", auth));
+                    }
+
+                    connect_req.push_str("\r\n");
+                    proxy_stream.writable().await.map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)?;
+                    proxy_stream.try_write(connect_req.as_bytes()).map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)?;
+
+                    let mut response = [0u8; 1024];
+                    proxy_stream.readable().await.map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)?;
+                    let n = proxy_stream.try_read(&mut response).map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)?;
+
+                    let response = String::from_utf8_lossy(&response[..n]);
+                    if !response.starts_with("HTTP/1.1 200") {
+                        return Err(Box::new(ProxyError(format!("Proxy CONNECT failed: {}", response))) as Box<dyn Error + Send + Sync>);
+                    }
+
+                    Ok(proxy_stream)
+                }
+            }
+        })
+    }
+}
+
+impl ProxyConnector {
+    pub fn new() -> Self {
+        if let Ok(socks_proxy) = env::var("SOCKS_PROXY") {
+            debug!("Using SOCKS proxy: {}", socks_proxy);
+            return ProxyConnector::Socks(socks_proxy);
+        }
+
+        if let Ok(http_proxy) = env::var("HTTP_PROXY").or_else(|_| env::var("HTTPS_PROXY")) {
+            debug!("Using HTTP proxy: {}", http_proxy);
+            return ProxyConnector::Http(http_proxy);
+        }
+
+        let mut connector = HttpConnector::new();
+        connector.enforce_http(false);
+        ProxyConnector::NoProxy(connector)
+    }
+}
+
+fn parse_proxy_addr(addr: &str) -> Result<(String, u16, Option<(String, String)>), Box<dyn Error + Send + Sync>> {
+    let uri: Uri = addr.parse()?;
+    let host = uri.host().ok_or("Missing proxy host")?.to_string();
+    let port = uri.port_u16().unwrap_or(if uri.scheme_str() == Some("https") { 443 } else { 80 });
+
+    let credentials = if let Some(authority) = uri.authority() {
+        if let Some(credentials) = authority.as_str().split('@').next() {
+            if credentials != authority.as_str() {
+                let creds: Vec<&str> = credentials.split(':').collect();
+                if creds.len() == 2 {
+                    Some((creds[0].to_string(), creds[1].to_string()))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    Ok((host, port, credentials))
+}
+
+
+fn get_target_addr(uri: &Uri) -> Result<String, Box<dyn Error + Send + Sync>> {
+    let host = uri.host().ok_or("Missing target host")?;
+    let port = uri.port_u16().unwrap_or(if uri.scheme_str() == Some("https") { 443 } else { 80 });
+    Ok(format!("{}:{}", host, port))
+}


### PR DESCRIPTION
Hi @sigaloid,

It has been a while since I initially proposed to add Support for Proxies. The project was still called LibReddit at that time - see original request: https://github.com/libreddit/libreddit/issues/841 . 

Further Issues that relate to that
- #339
- #184
- #1 

Since my instance is getting rate-limited frequently, people are already complaining about it, and I don't want to add further VPS (with new public IPs) just to circumvent the rate-limiting. So I finally decided to patch redlib to support HTTP_PROXY and SOCKS proxies.

## Changes in this MR

Redlib honors the following Environment-Variables:

- HTTP_PROXY
- HTTPS_PROXY
- SOCKS_PROXY

if `SOCKS_PROXY` is set, it'll take precedence over `HTTPS_PROXY` and `HTTP_PROXY`. Additionally the Environment Variables support authentication using the following format `scheme://username:password@host:port` (e.g. `http://proxyUsername:mySuperSecureProxyPassword@localhost:8090`).

For SOCKS support I introduced [tokio-socks](https://docs.rs/tokio-socks/latest/tokio_socks/) as dependency. For HTTP Proxy support, I just wrote a simple HTTP CONNECT wrapper. In all cases, consumers of the CLIENT won't notice a difference.

## Tests

I have tested HTTP Proxying with [TinyProxy](https://github.com/tinyproxy/tinyproxy) locally. And I have tested SOCKS Proxying with my VPN Providers SOCKS Proxy, and TOR proxying through a local [tor-socks-proxy](https://github.com/PeterDaveHello/tor-socks-proxy) container.


Would appreciate if you could review this MR - and maybe merge back. That'd make the world a better place - at least get rid of some rate-limits ^^

Cheers,
ruffy