### PR TITLE
fix: Use correct wget flag in Docker health check

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -37,7 +37,7 @@ USER redlib
 EXPOSE 8080
 
 # Run a healthcheck every minute to make sure redlib is functional
-HEALTHCHECK --interval=1m --timeout=3s CMD wget --spider --q http://localhost:8080/settings || exit 1
+HEALTHCHECK --interval=1m --timeout=3s CMD wget --spider -q http://localhost:8080/settings || exit 1
 
 # Add container metadata
 LABEL org.opencontainers.image.authors="sigaloid"

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -43,7 +43,7 @@ USER redlib
 EXPOSE 8080
 
 # Run a healthcheck every minute to make sure redlib is functional
-HEALTHCHECK --interval=1m --timeout=3s CMD wget --spider --q http://localhost:8080/settings || exit 1
+HEALTHCHECK --interval=1m --timeout=3s CMD wget --spider -q http://localhost:8080/settings || exit 1
 
 # Add container metadata
 LABEL org.opencontainers.image.authors="sigaloid"


### PR DESCRIPTION
The flag `--q` does not exist; it's either `--quiet` or `-q`, and this PR updates the relevant Dockerfiles to use the latter.