### PR TITLE
Document MSRV of Rust 1.81

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
     "spikecodes <19519553+spikecodes@users.noreply.github.com>",
 ]
 edition = "2021"
+rust-version = "1.81"
 default-run = "redlib"
 
 [dependencies]


### PR DESCRIPTION
Found using [`cargo-msrv`][1]. It's good to document this so that contributors know when using a new language feature will require a semver break.

Rust 1.81 is currently required by `litemap` 0.7.5 and `zerofrom` 0.1.6, which are both in `url`'s dependency tree.

[1]: https://github.com/foresterre/cargo-msrv