### PR TITLE
build(dev): add live development environment with cargo-watch

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,24 @@
+# Development Dockerfile - prepares dev environment for live compilation
+# supported versions here: https://hub.docker.com/_/rust
+ARG ALPINE_VERSION=3.20
+
+FROM rust:alpine${ALPINE_VERSION}
+
+RUN apk add --no-cache musl-dev wget
+
+WORKDIR /redlib
+
+# Pre-download dependencies (will be cached in Docker volume)
+COPY Cargo.lock Cargo.toml ./
+RUN mkdir -p src && echo "fn main() {}" > src/main.rs && \
+    cargo build --bin redlib && \
+    rm -rf src
+
+# Install cargo-watch for automatic recompilation on file changes
+RUN cargo install cargo-watch
+
+EXPOSE 8080
+
+# Use cargo-watch to automatically recompile and restart on source changes
+CMD ["cargo", "watch", "-x", "run --bin redlib"]
+

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,26 +1,37 @@
-# docker-compose -f docker-compose.dev.yml up -d
-version: "3.8"
+# docker compose -f compose.dev.yaml up
+# Development setup - source mounted read-only, build cache in Docker volumes
 
 services:
   redlib:
-    build: .
-    restart: always
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
     container_name: "redlib"
     ports:
-      - 8080:8080 # Specify `127.0.0.1:8080:8080` instead if using a reverse proxy
-    user: nobody
-    read_only: true
-    security_opt:
-      - no-new-privileges:true
-      # - seccomp=seccomp-redlib.json
-    cap_drop:
-      - ALL
+      - 8080:8080
+    volumes:
+      # Mount source code as read-only - code changes trigger rebuild
+      - ./src:/redlib/src:ro
+      - ./templates:/redlib/templates:ro
+      - ./static:/redlib/static:ro
+      - ./Cargo.toml:/redlib/Cargo.toml:ro
+      - ./Cargo.lock:/redlib/Cargo.lock:ro
+      - ./build.rs:/redlib/build.rs:ro
+      # Build artifacts stay in Docker volumes (not on your disk)
+      - redlib-target:/redlib/target
+      - redlib-cargo:/usr/local/cargo
+    environment:
+      - RUST_LOG=debug
     networks:
       - redlib
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "--tries=1", "http://localhost:8080/settings"]
       interval: 5m
       timeout: 3s
+
+volumes:
+  redlib-target:
+  redlib-cargo:
 
 networks:
   redlib:


### PR DESCRIPTION
# build(dev): add live development environment with cargo-watch

- Add Dockerfile.dev with cargo-watch for automatic recompilation on file changes
- Configure compose.dev.yaml with read-only volume mounts for source code
- Use Docker volumes for build artifacts to keep host filesystem clean
- Enable RUST_LOG=debug for development logging
- Update comment to use modern 'docker compose' syntax

Development workflow:
- Start: docker compose -f compose.dev.yaml up --build
- Edit code and cargo-watch automatically recompiles
- No manual rebuilds or restarts needed

Fixes #313 - probably
