### PR TITLE
fix(video): add support for CMAF video format alongside DASH

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -264,7 +264,8 @@ async fn main() {
 	app.at("/instances.json").get(|_| async move { proxy_instances().await }.boxed());
 
 	// Proxy media through Redlib
-	app.at("/vid/:id/:size").get(|r| proxy(r, "https://v.redd.it/{id}/DASH_{size}").boxed());
+	app.at("/vid/:id/dash/:size").get(|r| proxy(r, "https://v.redd.it/{id}/DASH_{size}").boxed());
+	app.at("/vid/:id/cmaf/:size").get(|r| proxy(r, "https://v.redd.it/{id}/CMAF_{size}").boxed());
 	app.at("/hls/:id/*path").get(|r| proxy(r, "https://v.redd.it/{id}/{path}").boxed());
 	app.at("/img/*path").get(|r| proxy(r, "https://i.redd.it/{path}").boxed());
 	app.at("/thumb/:point/:id").get(|r| proxy(r, "https://{point}.thumbs.redditmedia.com/{id}").boxed());


### PR DESCRIPTION
Reddit has transitioned from DASH to CMAF video format. This change adds support for both formats to maintain compatibility.

Changes:
- Update REGEX_URL_VIDEOS to match both DASH and CMAF formats
- Add format capture group to preserve DASH/CMAF in URL path
- Add separate proxy endpoints for /vid/:id/dash/:size and /vid/:id/cmaf/:size
- Update format_url to handle 3-segment video URLs (id/format/size)
- Update tests to reflect new URL format with format segment

Video URLs now follow pattern: /vid/{id}/{format}/{size}.mp4
Example: /vid/abc123/cmaf/720.mp4

Fixes #503
Fixes #504