### PR TITLE
Avoid 403 by Changing Ciphers List

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,6 +1418,7 @@ dependencies = [
  "route-recognizer",
  "rss",
  "rust-embed",
+ "rustls",
  "sealed_test",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ bincode = "1.3.3"
 base2048 = "2.0.2"
 revision = "0.10.0"
 fake_user_agent = "0.2.2"
-
+rustls = "0.21.12"
 
 [dev-dependencies]
 lipsum = "0.9.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,7 @@ use futures_lite::{future::Boxed, FutureExt};
 use hyper::client::HttpConnector;
 use hyper::header::HeaderValue;
 use hyper::{body, body::Buf, header, Body, Client, Method, Request, Response, Uri};
-use hyper_rustls::HttpsConnector;
+use hyper_rustls::{ConfigBuilderExt, HttpsConnector};
 use libflate::gzip;
 use log::{error, trace, warn};
 use percent_encoding::{percent_encode, CONTROLS};
@@ -30,8 +30,36 @@ const REDDIT_SHORT_URL_BASE_HOST: &str = "redd.it";
 const ALTERNATIVE_REDDIT_URL_BASE: &str = "https://www.reddit.com";
 const ALTERNATIVE_REDDIT_URL_BASE_HOST: &str = "www.reddit.com";
 
-pub static HTTPS_CONNECTOR: LazyLock<HttpsConnector<HttpConnector>> =
-	LazyLock::new(|| hyper_rustls::HttpsConnectorBuilder::new().with_native_roots().https_only().enable_http2().build());
+pub static HTTPS_CONNECTOR: LazyLock<HttpsConnector<HttpConnector>> = LazyLock::new(|| {
+	hyper_rustls::HttpsConnectorBuilder::new()
+		.with_tls_config(
+			rustls::ClientConfig::builder()
+				// These are the Firefox 145.0 cipher suite,
+				// minus the suites missing forward-secrecy support,
+				// in the same order.
+				// https://github.com/redlib-org/redlib/issues/446#issuecomment-3609306592
+				.with_cipher_suites(&[
+					rustls::cipher_suite::TLS13_AES_256_GCM_SHA384,
+					rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
+					rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+					rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+					rustls::cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+					rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				])
+				// .with_safe_default_cipher_suites()
+				.with_safe_default_kx_groups()
+				.with_safe_default_protocol_versions()
+				.unwrap()
+				.with_native_roots()
+				.with_no_client_auth(),
+		)
+		.https_only()
+		.enable_http2()
+		.build()
+});
 
 pub static CLIENT: LazyLock<Client<HttpsConnector<HttpConnector>>> = LazyLock::new(|| Client::builder().build::<_, Body>(HTTPS_CONNECTOR.clone()));
 


### PR DESCRIPTION
As mentioned here https://github.com/redlib-org/redlib/issues/446#issuecomment-3609306592, and investigated further here https://github.com/redlib-org/redlib/issues/446#issuecomment-3609487389, reddit seems to be blocking on the exact ciphers default in rusttls.

This PR sets the list to that of Firefox.