### PR TITLE
Increase touch area of comment collapse button on mobile

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2075,7 +2075,8 @@ th {
         margin-left: 12px;
     }
     .comment_data {
-        margin-left: 12px;
+        margin-left: 8px;
+        padding-left: 8px;
     }
 
     .user-comment .comment_data {


### PR DESCRIPTION
This pull request adds extra padding to the left of the "arrow" marker on comment threads, improving the consistency of the touch area to the left of the commenter's username (which previously didn't extend past the left side of the arrow marker).

This change should improve the overall UX of Redlib by making comments easier to collapse (since I believe most users won't know you can tap to the *right* of the username and creation date, and will go straight for the arrow marker instead). Since the area is increased on the left side of the "arrow" marker, it will also reduce accidental taps of the commenter's username (taking them to the user's page, which counts against Reddit's rate limiting).

Closes #500.