### PR TITLE
Fix default post sort setting not applied until settings are saved

### DIFF
--- a/src/subreddit.rs
+++ b/src/subreddit.rs
@@ -68,7 +68,7 @@ pub async fn community(req: Request<Body>) -> Result<Response<Body>, String> {
 	let subscribed = setting(&req, "subscriptions");
 	let front_page = setting(&req, "front_page");
 	let remove_default_feeds = setting(&req, "remove_default_feeds") == "on";
-	let post_sort = req.cookie("post_sort").map_or_else(|| "hot".to_string(), |c| c.value().to_string());
+	let post_sort = setting(&req, "post_sort");
 	let sort = req.param("sort").unwrap_or_else(|| req.param("id").unwrap_or(post_sort));
 
 	let sub_name = req.param("sub").unwrap_or(if front_page == "default" || front_page.is_empty() {


### PR DESCRIPTION
Before this commit, the instance default post sort will not be applied until the user saves (not even changes) their settings at least once. See #501 for a detailed description of the bug. This PR changes the subreddit page to try the instance default setting if no cookie exists (using an existing utility function that appears to already be used everywhere else - perhaps post sort was forgotten when the function was first introduced?)

Fixes #501.