### PR TITLE
Improve searchbox outline when focusing

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -706,6 +706,10 @@ select,
     margin-bottom: 0;
 }
 
+#searchbox:focus-within {   
+    outline: 2px solid var(--accent);
+}
+
 #searchbox > *,
 #sort_submit {
     background: var(--highlighted);


### PR DESCRIPTION
When focusing the searchbox, the entire search form should get an outline instead of just the search input field.

This was done with the `:focus-within` selector for the form, which should be available to all modern broswers https://caniuse.com/css-focus-within

This is how it looked previously:
<img width="498" height="66" alt="image" src="https://github.com/user-attachments/assets/b6c84ddd-6646-426c-8248-835cc1034a55" />

With this commit:
<img width="446" height="59" alt="image" src="https://github.com/user-attachments/assets/8b498691-fb62-4b8b-96e8-43a5b93315a0" />
