### PR TITLE
Lazy load post images

### DIFF
--- a/templates/utils.html
+++ b/templates/utils.html
@@ -104,20 +104,7 @@
 	{% if post.post_type == "image" %}
 	<div class="post_media_content">
 		<a href="{{ post.media.url }}" class="post_media_image" >
-			{% if post.media.height == 0 || post.media.width == 0 %}
-			<!-- i.redd.it images special case -->
 			<img width="100%" height="100%" loading="lazy" alt="Post image" src="{{ post.media.url }}"/>
-			{% else %}
-			<svg
-				width="{{ post.media.width }}px"
-				height="{{ post.media.height }}px"
-				xmlns="http://www.w3.org/2000/svg">
-					<image width="100%" height="100%" href="{{ post.media.url }}"/>
-					<desc>
-						<img loading="lazy" alt="Post image" src="{{ post.media.url }}"/>
-					</desc>
-			</svg>
-			{% endif %}
 		</a>
 	</div>
 	{% else if post.post_type == "video" || post.post_type == "gif" %}
@@ -253,20 +240,7 @@
 	{% if (prefs.layout.is_empty() || prefs.layout == "card") && post.post_type == "image" %}
 	<div class="post_media_content">
 		<a href="{{ post.media.url }}" class="post_media_image {% if post.media.height < post.media.width*2 %}short{% endif %}" >
-			{% if post.media.height == 0 || post.media.width == 0 %}
-			<!-- i.redd.it images speical case -->
 			<img width="100%" height="100%" loading="lazy" alt="Post image" src="{{ post.media.url }}"/>
-			{% else %}
-			<svg
-				width="{{ post.media.width }}px"
-				height="{{ post.media.height }}px"
-				xmlns="http://www.w3.org/2000/svg">
-					<image width="100%" height="100%" href="{{ post.media.url }}"/>
-					<desc>
-						<img loading="lazy" alt="Post image" src="{{ post.media.url }}"/>
-					</desc>
-			</svg>
-			{% endif %}
 		</a>
 	</div>
 	{% else if (prefs.layout.is_empty() || prefs.layout == "card") && (post.post_type == "gif" || post.post_type == "video") %}
@@ -292,12 +266,7 @@
 		</svg>
 		{% else %}
 		<div style="max-width:{{ post.thumbnail.width }}px;max-height:{{ post.thumbnail.height }}px;">
-			<svg width="{{ post.thumbnail.width }}px" height="{{ post.thumbnail.height }}px" xmlns="http://www.w3.org/2000/svg">
-				<image width="100%" height="100%" href="{{ post.thumbnail.url }}"/>
-				<desc>
-					<img loading="lazy" alt="Thumbnail" src="{{ post.thumbnail.url }}"/>
-				</desc>
-			</svg>
+			<img width="100%" height="100%" loading="lazy" alt="Thumbnail" src="{{ post.thumbnail.url }}"/>
 		</div>
 		{% endif %}
 		<span>{% if post.post_type == "link" %}{{ post.domain }}{% else %}{{ post.post_type }}{% endif %}</span>


### PR DESCRIPTION
The `<image>` items don't appear to be a real thing despite displaying the image, and they didn't support `loading="lazy"` so this basically just sets post images to always use the normal `<img>` tag and get rid of all the svg stuff that wasn't doing anything.