### PR TITLE
Prevent an out of bounds from trying to access comments[0].author.name when there are no comments

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -2,7 +2,7 @@
 {% import "utils.html" as utils %}
 
 {% block title %}
-	{% if single_thread %}
+	{% if single_thread && comments.len() > 0 %}
 		{{ comments[0].author.name }} comments on {{ post.title }} - r/{{ post.community }}
 	{% else %}
 		{{ post.title }} - r/{{ post.community }}


### PR DESCRIPTION
This fixes https://github.com/redlib-org/redlib/issues/496.

This can happen naturally when trying to view a comment that has been totally deleted from Reddit (where they warn "This comment no longer exists"), but can also be triggered intentionally by entering a nonsense comment ID.

With this PR the post is viewable and no comments appear when this happens, but this gives no warning that the comment was fully deleted or was invalid. I also created a version where an error page is display instead, but since that prevents you from seeing the post I decided this was the better option instead.

I'd prefer some way of having a warning about the comment being gone while still being able to view the post but I'm not sure there's any easy way to do this.