### PR TITLE
fix: support rich:video (transcoded external media) and CMAF format

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -264,7 +264,7 @@ async fn main() {
 	app.at("/instances.json").get(|_| async move { proxy_instances().await }.boxed());
 
 	// Proxy media through Redlib
-	app.at("/vid/:id/:size").get(|r| proxy(r, "https://v.redd.it/{id}/DASH_{size}").boxed());
+	app.at("/vid/:id/:prefix/:size").get(|r| proxy(r, "https://v.redd.it/{id}/{prefix}_{size}").boxed());
 	app.at("/hls/:id/*path").get(|r| proxy(r, "https://v.redd.it/{id}/{path}").boxed());
 	app.at("/img/*path").get(|r| proxy(r, "https://i.redd.it/{path}").boxed());
 	app.at("/thumb/:point/:id").get(|r| proxy(r, "https://{point}.thumbs.redditmedia.com/{id}").boxed());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -213,6 +213,12 @@ impl Media {
 				&crosspost_parent_media["fallback_url"],
 				Some(&crosspost_parent_media["hls_url"]),
 			)
+		} else if data["post_hint"].as_str().unwrap_or("") == "rich:video" && data_preview["fallback_url"].is_string() {
+			(
+				if data_preview["is_gif"].as_bool().unwrap_or(false) { "gif" } else { "video" },
+				&data_preview["fallback_url"],
+				Some(&data_preview["hls_url"]),
+			)
 		} else if data["post_hint"].as_str().unwrap_or("") == "image" {
 			// Handle images, whether GIFs or pics
 			let preview = &data["preview"]["images"][0];
@@ -1007,7 +1013,7 @@ static REGEX_URL_WWW: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"https?://w
 static REGEX_URL_OLD: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"https?://old\.reddit\.com/(.*)").unwrap());
 static REGEX_URL_NP: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"https?://np\.reddit\.com/(.*)").unwrap());
 static REGEX_URL_PLAIN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"https?://reddit\.com/(.*)").unwrap());
-static REGEX_URL_VIDEOS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"https?://v\.redd\.it/(.*)/DASH_([0-9]{2,4}(\.mp4|$|\?source=fallback))").unwrap());
+static REGEX_URL_VIDEOS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"https?://v\.redd\.it/(.*)/(DASH|CMAF)_([0-9]{2,4}(\.mp4|$|\?source=fallback))").unwrap());
 static REGEX_URL_VIDEOS_HLS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"https?://v\.redd\.it/(.+)/(HLSPlaylist\.m3u8.*)$").unwrap());
 static REGEX_URL_IMAGES: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"https?://i\.redd\.it/(.*)").unwrap());
 static REGEX_URL_THUMBS_A: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"https?://a\.thumbs\.redditmedia\.com/(.*)").unwrap());
@@ -1030,6 +1036,7 @@ pub fn format_url(url: &str) -> String {
 				regex.captures(url).map_or(String::new(), |caps| match segments {
 					1 => [format, &caps[1]].join(""),
 					2 => [format, &caps[1], "/", &caps[2]].join(""),
+					3 => [format, &caps[1], "/", &caps[2], "/", &caps[3]].join(""),
 					_ => String::new(),
 				})
 			};
@@ -1060,7 +1067,7 @@ pub fn format_url(url: &str) -> String {
 				"old.reddit.com" => capture(&REGEX_URL_OLD, "/", 1),
 				"np.reddit.com" => capture(&REGEX_URL_NP, "/", 1),
 				"reddit.com" => capture(&REGEX_URL_PLAIN, "/", 1),
-				"v.redd.it" => chain!(capture(&REGEX_URL_VIDEOS, "/vid/", 2), capture(&REGEX_URL_VIDEOS_HLS, "/hls/", 2)),
+				"v.redd.it" => chain!(capture(&REGEX_URL_VIDEOS, "/vid/", 3), capture(&REGEX_URL_VIDEOS_HLS, "/hls/", 2)),
 				"i.redd.it" => capture(&REGEX_URL_IMAGES, "/img/", 1),
 				"a.thumbs.redditmedia.com" => capture(&REGEX_URL_THUMBS_A, "/thumb/a/", 1),
 				"b.thumbs.redditmedia.com" => capture(&REGEX_URL_THUMBS_B, "/thumb/b/", 1),
@@ -1499,7 +1506,7 @@ mod tests {
 			format_url("https://preview.redd.it/qwerty.jpg?auto=webp&s=asdf"),
 			"/preview/pre/qwerty.jpg?auto=webp&s=asdf"
 		);
-		assert_eq!(format_url("https://v.redd.it/foo/DASH_360.mp4?source=fallback"), "/vid/foo/360.mp4");
+		assert_eq!(format_url("https://v.redd.it/foo/DASH_360.mp4?source=fallback"), "/vid/foo/DASH/360.mp4");
 		assert_eq!(
 			format_url("https://v.redd.it/foo/HLSPlaylist.m3u8?a=bar&v=1&f=sd"),
 			"/hls/foo/HLSPlaylist.m3u8?a=bar&v=1&f=sd"


### PR DESCRIPTION
  This PR addresses the issue where Gifs and other third-party video providers (flagged by Reddit as rich:video) fail to load or display a video player.

  The problem revolves around Reddit has shifted how it handles external video embeds. Instead of just providing an oembed/iframe, it now transcodes many of these videos into its own v.redd.it infrastructure maybe for better mobile perf ? who knows ? These new transcodes differ from standard Reddit videos in two ways:
   
   1. They are categorized in the API under the post_hint: "rich:video" instead of the standard "video" hint.
   2. They use the CMAF (Common Media Application Format) AKA newer standard container, instead of the older DASH format. This manifests in the URL as a CMAF_ prefix (e.g., CMAF_1080.mp4) rather than the DASH_ prefix Redlib expects.


  Because Redlib was looking specifically for DASH_ in both its regex logic and its proxy routing, these videos were being ignored or resulting in 404/403 errors when the browser tried to load them without the proxy.

  Overall the changes are:
   * src/utils.rs:
       * Updated Media::parse to support the rich:video post hint. It now attempts to extract the video data from the reddit_video_preview object which contains the Reddit-hosted fallback URLs.
       * Updated REGEX_URL_VIDEOS to support both DASH_ and CMAF_ prefixes.
       * Updated format_url to handle a 3-segment structure for video proxies (/vid/ID/PREFIX/SIZE), allowing the format prefix to be passed dynamically to the proxy.
       * Added tests for coverage.
   * src/main.rs:
       * Refactored the /vid/ proxy route to be generic. It no longer hardcodes DASH_ and instead accepts a :prefix parameter. This makes the proxy futureproof for any other formats Reddit might introduce (like HLS_).

 I tested on r/highqualitygifs and r/gifs, which appeared to be the biggest "offenders" using the CMAF container. Everything clicks.

Fix:  redlib-org/redlib#20
Simpler/safer approach over PR: redlib-org/redlib#507 which focuses on fixing one edge case while adding a lot of dependencies/brittle code, since any API change will break this specific implementation.