### PR TITLE
build(nix): update deps

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1731974733,
-        "narHash": "sha256-enYSSZVVl15FI5p+0Y5/Ckf5DZAvXe6fBrHxyhA/njc=",
+        "lastModified": 1777242778,
+        "narHash": "sha256-VWTeqWeb8Sel/QiWyaPvCa9luAbcGawR+Rw09FJoHz0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "3cb338ce81076ce5e461cf77f7824476addb0e1c",
+        "rev": "ad8b31ad0ba8448bd958d7a5d50d811dc5d271c0",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731890469,
-        "narHash": "sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs=",
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5083ec887760adfe12af64830a66807423a859a7",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732069891,
-        "narHash": "sha256-moKx8AVJrViCSdA0e0nSsG8b1dAsObI4sRAtbqbvBY8=",
+        "lastModified": 1777259803,
+        "narHash": "sha256-fIb/EoVu/1U0qVrE6qZCJ2WCfprRpywNIAVzKEACIQc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8509a51241c407d583b1963d5079585a992506e8",
+        "rev": "a6cb2224d975e16b5e67de688c6ad306f7203425",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -24,12 +24,9 @@
 
         inherit (pkgs) lib;
 
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
-          targets = [ "x86_64-unknown-linux-musl" ];
-        };
+        rustToolchain = pkgs.rust-bin.stable.latest.default;
 
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
-
 
         src = lib.cleanSourceWith {
           src = craneLib.path ./.;
@@ -39,13 +36,18 @@
             (craneLib.filterCargoSources path type);
         };
 
-        redlib = craneLib.buildPackage {
+        redlib = with pkgs; craneLib.buildPackage {
           inherit src;
           strictDeps = true;
           doCheck = false;
 
-          CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
-          CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+          nativeBuildInputs = [
+            git
+            cmake
+            clang
+          ];
+
+          LIBCLANG_PATH = "${libclang.lib}/lib";
         };
       in
       {


### PR DESCRIPTION
Currently locked deps are too old to build the latest version of redlib. `flake.lock` was last updated on 2024-11-21 (#331).

```
error: Cannot build '/nix/store/6x3c45nx3dbfn9c3ki9rw0f7nrw8xyfr-redlib-deps-0.36.0.drv'.
       Reason: builder failed with exit code 101.
       Output paths:
         /nix/store/93hfp3vnagbhnz95gf2kyyvbdf6vslbc-redlib-deps-0.36.0
       Last 25 log lines:
       > default configurePhase, nothing to do
       > Running phase: buildPhase
       > ++ command cargo --version
       > cargo 1.82.0 (8f40fc59f 2024-08-21)
       > ++ command cargo check --release --locked
       > error: failed to get `arc-swap` as a dependency of package `redlib v0.36.0 (/build/source)`
       >
       > Caused by:
       >   failed to load source for dependency `arc-swap`
       >
       > Caused by:
       >   Unable to update registry `crates-io`
       >
       > Caused by:
       >   failed to update replaced source registry `crates-io`
       >
       > Caused by:
       >   failed to parse manifest at `/nix/store/qgn21px5h6fnjw05wpryjm69gkyg0j3x-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/revision-derive-0.17.0/Cargo.toml`
       >
       > Caused by:
       >   feature `edition2024` is required
       >
       >   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.82.0 (8f40fc59f 2024-08-21)).
       >   Consider trying a newer version of Cargo (this may require the nightly release).
       >   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
       For full logs, run:
         nix log /nix/store/6x3c45nx3dbfn9c3ki9rw0f7nrw8xyfr-redlib-deps-0.36.0.drv
```