### PR TITLE
feat: proxy and embed giphy gifs in comments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -276,6 +276,7 @@ async fn main() {
 	app.at("/preview/:loc/:id").get(|r| proxy(r, "https://{loc}view.redd.it/{id}").boxed());
 	app.at("/style/*path").get(|r| proxy(r, "https://styles.redditmedia.com/{path}").boxed());
 	app.at("/static/*path").get(|r| proxy(r, "https://www.redditstatic.com/{path}").boxed());
+	app.at("/giphy/:id/:ext").get(|r| proxy(r, "https://media.giphy.com/media/{id}/giphy.{ext}").boxed());
 
 	// Browse user profile
 	app

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1158,6 +1158,24 @@ pub fn rewrite_urls(input_text: &str) -> String {
 	}
 }
 
+// Match Giphy URLs in comment anchor tags, capturing the GIF ID
+// Handles: giphy.com/gifs/ID, media.giphy.com/media/ID, i.giphy.com/ID
+static GIPHY_EMBED_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+	Regex::new(r#"(?i)<a\s+href="https?://(?:www\.)?(?:giphy\.com/(?:gifs|clips)|media\.giphy\.com/media|i\.giphy\.com)/([a-z0-9]+)[^"]*"[^>]*>[^<]*</a>"#).unwrap()
+});
+
+/// Rewrite Giphy URLs in comment body to embedded video elements
+fn rewrite_giphy_links(comment: &str) -> String {
+	GIPHY_EMBED_REGEX
+		.replace_all(comment, |caps: &regex::Captures| {
+			let id = &caps[1];
+			format!(
+				r#"<div class="giphy-embed-container"><a href="/giphy/{id}/gif"><video class="giphy-embed" loop poster="/giphy/{id}/gif"><source src="/giphy/{id}/mp4" type="video/mp4"></video></a></div>"#
+			)
+		})
+		.to_string()
+}
+
 // These links all follow a pattern of "https://reddit-econ-prod-assets-permanent.s3.amazonaws.com/asset-manager/SUBREDDIT_ID/RANDOM_FILENAME.png"
 static REDDIT_EMOTE_LINK_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"https://reddit-econ-prod-assets-permanent.s3.amazonaws.com/asset-manager/(.*)"#).unwrap());
 
@@ -1236,7 +1254,10 @@ pub fn rewrite_emotes(media_metadata: &Value, comment: String) -> String {
 	comment = render_bullet_lists(&comment);
 
 	// Call rewrite_urls() to transform any other Reddit links
-	rewrite_urls(&comment)
+	let comment = rewrite_urls(&comment);
+
+	// Rewrite Giphy links to embedded videos
+	rewrite_giphy_links(&comment)
 }
 
 /// Format vote count to a string that will be displayed.

--- a/static/style.css
+++ b/static/style.css
@@ -1385,12 +1385,19 @@ a.search_subreddit:hover {
     display: flex;
 }
 
+.giphy-embed-container,
 .comment img {
     max-width: 50%;
     height: auto;
 }
 
+.giphy-embed {
+    width: 100%;
+    display: flex;
+}
+
 @media screen and (max-width: 500px) {
+    .giphy-embed-container,
     .comment img {
         max-width: 80%;
         height: auto;
@@ -1978,7 +1985,7 @@ th {
         max-width: 100%;
     }
     #user { margin: 0 0 20px; }
-    
+
     body.fixed_navbar {
         min-height: calc(100vh - 75px);
         padding-top: 45px;


### PR DESCRIPTION
Closes #547 

Before, the link would be shown without any embedding. To see the gif, you would need to open the gif link. Now, the gif is proxied through the instance and embedded to the user. Clicking on the gif opens the gif through the proxied link.

Example: ``r/cats/comments/1ugv599/wake_up_complaint_and_goes_to_sleep_again/ou30fs7/?context=3#ou30fs7``

Before:
<img width="970" height="180" alt="image" src="https://github.com/user-attachments/assets/ff801ea3-44d0-4502-b611-a5a04207240a" />

After (looping gif):
<img width="996" height="745" alt="image" src="https://github.com/user-attachments/assets/d2e390ae-53e5-41bf-9fa7-5820f58085a3" />
