### PR TITLE
feat: make source code URL in footer configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,15 +408,16 @@ Redlib supports the following command line flags:
 
 Assign a default value for each instance-specific setting by passing environment variables to Redlib in the format `REDLIB_{X}`. Replace `{X}` with the setting name (see list below) in capital letters.
 
-| Name                      | Possible values | Default value          | Description                                                                                               |
-|---------------------------|-----------------|------------------------|-----------------------------------------------------------------------------------------------------------|
-| `SFW_ONLY`                | `["on", "off"]` | `off`                  | Enables SFW-only mode for the instance, i.e. all NSFW content is filtered.                                |
-| `BANNER`                  | String          | (empty)                | Allows the server to set a banner to be displayed. Currently this is displayed on the instance info page. |
-| `ROBOTS_DISABLE_INDEXING` | `["on", "off"]` | `off`                  | Disables indexing of the instance by search engines.                                                      |
-| `PUSHSHIFT_FRONTEND`      | String          | `undelete.pullpush.io` | Allows the server to set the Pushshift frontend to be used with "removed" links.                          |
-| `PORT`                    | Integer 0-65535 | `8080`                 | The **internal** port Redlib listens on.                                                                  |
-| `ENABLE_RSS`              | `["on", "off"]` | `off`                  | Enables RSS feed generation.                                                                              |
-| `FULL_URL`                | String          | (empty)                | Allows for proper URLs (for now, only needed by RSS)                                                      |
+| Name                      | Possible values | Default value                          | Description                                                                                               |
+|---------------------------|-----------------|----------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `SFW_ONLY`                | `["on", "off"]` | `off`                                  | Enables SFW-only mode for the instance, i.e. all NSFW content is filtered.                                |
+| `BANNER`                  | String          | (empty)                                | Allows the server to set a banner to be displayed. Currently this is displayed on the instance info page. |
+| `ROBOTS_DISABLE_INDEXING` | `["on", "off"]` | `off`                                  | Disables indexing of the instance by search engines.                                                      |
+| `PUSHSHIFT_FRONTEND`      | String          | `undelete.pullpush.io`                 | Allows the server to set the Pushshift frontend to be used with "removed" links.                          |
+| `PORT`                    | Integer 0-65535 | `8080`                                 | The **internal** port Redlib listens on.                                                                  |
+| `ENABLE_RSS`              | `["on", "off"]` | `off`                                  | Enables RSS feed generation.                                                                              |
+| `FULL_URL`                | String          | (empty)                                | Allows for proper URLs (for now, only needed by RSS)                                                      |
+| `SOURCE_URL`              | String          | `https://github.com/redlib-org/redlib` | Link to the source code for this instance.
 
 ## Default user settings
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,6 +108,9 @@ pub struct Config {
 
 	#[serde(rename = "REDLIB_DEFAULT_REMOVE_DEFAULT_FEEDS")]
 	pub(crate) default_remove_default_feeds: Option<String>,
+
+	#[serde(rename = "REDLIB_SOURCE_URL")]
+	pub(crate) source_url: Option<String>,
 }
 
 impl Config {
@@ -156,6 +159,7 @@ impl Config {
 			enable_rss: parse("REDLIB_ENABLE_RSS"),
 			full_url: parse("REDLIB_FULL_URL"),
 			default_remove_default_feeds: parse("REDLIB_DEFAULT_REMOVE_DEFAULT_FEEDS"),
+			source_url: parse("REDLIB_SOURCE_URL"),
 		}
 	}
 }
@@ -186,6 +190,7 @@ fn get_setting_from_config(name: &str, config: &Config) -> Option<String> {
 		"REDLIB_ENABLE_RSS" => config.enable_rss.clone(),
 		"REDLIB_FULL_URL" => config.full_url.clone(),
 		"REDLIB_DEFAULT_REMOVE_DEFAULT_FEEDS" => config.default_remove_default_feeds.clone(),
+		"REDLIB_SOURCE_URL" => config.source_url.clone(),
 		_ => None,
 	}
 }
@@ -261,6 +266,12 @@ mod tests {
 	#[sealed_test(env = [("REDLIB_DEFAULT_FILTERS", "news+bestof")])]
 	fn test_default_filters() {
 		assert_eq!(get_setting("REDLIB_DEFAULT_FILTERS"), Some("news+bestof".into()));
+	}
+
+	#[test]
+	#[sealed_test(env = [("REDLIB_SOURCE_URL", "https://example.com")])]
+	fn test_source_url() {
+		assert_eq!(get_setting("REDLIB_SOURCE_URL"), Some("https://example.com".into()));
 	}
 
 	#[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1381,6 +1381,12 @@ pub fn disable_indexing() -> bool {
 	}
 }
 
+/// Returns the currently configured source code URL to display in the footer.
+/// Defaults to the upstream Github repository URL when not explicitly configured.
+pub fn get_source_url() -> String {
+	get_setting("REDLIB_SOURCE_URL").unwrap_or("https://github.com/redlib-org/redlib".into())
+}
+
 /// Determines if a request should redirect to a NSFW landing gate.
 pub fn should_be_nsfw_gated(req: &Request<Body>, _req_url: &str) -> bool {
 	(setting(req, "show_nsfw") != "on") || sfw_only()

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,7 +77,7 @@
 		{% block footer %}
 			<footer>
 				<div class="footer-buttons">
-					<p><span id="version">v{{ env!("CARGO_PKG_VERSION") }}&emsp;</span><a href="/info" title="View instance information">ⓘ View instance info</a>&emsp;<a href="https://github.com/redlib-org/redlib" title="View code on GitHub">&lt;&gt; Code</a></p>
+					<p><span id="version">v{{ env!("CARGO_PKG_VERSION") }}&emsp;</span><a href="/info" title="View instance information">ⓘ View instance info</a>&emsp;<a href="{{ crate::utils::get_source_url() }}" title="View source code">&lt;&gt; Code</a></p>
 				</div>
 			</footer>
 		{% endblock %}


### PR DESCRIPTION
This PR adds a new environment variable, `REDLIB_SOURCE_URL`, that can be used to configure where the source code link in the website footer leads to.

Motivation for this one was to ensure that instance administrators running forks/modified copies of Redlib have an easy way to remain compliant with the AGPL, by providing a link to the currently running source code. One might argue that anyone modifying the source already should just edit the hardcoded URL, but that's a bit annoying if, for example, the fork maintainer intends to submit their changes back upstream. For those cases, a simpler runtime override is easier to manage.